### PR TITLE
Gdpr compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ public class MainActivity extends AppCompatActivity {
     private CCPAConsentLib ccpaConsentLib;
 
     private CCPAConsentLib buildAndRunConsentLib(Boolean showPM) throws ConsentLibException {
-        private CCPAConsentLib buildAndRunConsentLib(Boolean showPM) throws ConsentLibException {
         return CCPAConsentLib.newBuilder(22, "ccpa.mobile.demo", 6099,"5df9105bcf42027ce707bb43",this)
                 .setViewGroup(findViewById(android.R.id.content))
                 .setOnMessageReady(consentLib -> Log.i(TAG, "onMessageReady"))

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,7 +28,7 @@ android {
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation 'com.android.support:appcompat-v7:26.1.0'
+    implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation 'com.android.support.constraint:constraint-layout:1.1.2'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
@@ -36,4 +36,5 @@ dependencies {
     implementation 'com.android.volley:volley:1.1.1'
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation project(':ccpa_cmplibrary')
+    implementation 'com.sourcepoint.cmplibrary:cmplibrary:4.0.0'
 }

--- a/app/src/main/java/com/sourcepoint/test_project/MainActivity.java
+++ b/app/src/main/java/com/sourcepoint/test_project/MainActivity.java
@@ -30,7 +30,7 @@ public class MainActivity extends AppCompatActivity {
             mainViewGroup.removeView(webView);
     }
 
-    private CCPAConsentLib buildAndRunConsentLib() throws ConsentLibException {
+    private CCPAConsentLib buildAndRunConsentLib() {
         return CCPAConsentLib.newBuilder(22, "ccpa.mobile.demo", 6099,"5df9105bcf42027ce707bb43",this)
                 .setOnConsentUIReady(consentLib -> {
                     showMessageWebView(consentLib.webView);
@@ -58,7 +58,6 @@ public class MainActivity extends AppCompatActivity {
                 })
                 .setOnError(consentLib -> {
                     Log.e(TAG, "Something went wrong: ", consentLib.error);
-                    removeWebView(consentLib.webView);
                 })
                 .build();
     }
@@ -66,14 +65,8 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onResume() {
         super.onResume();
-        try {
-            ccpaConsentLib = buildAndRunConsentLib();
-            ccpaConsentLib.run();
-        } catch (ConsentLibException e) {
-            e.printStackTrace();
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+        ccpaConsentLib = buildAndRunConsentLib();
+        ccpaConsentLib.run();
     }
 
     @Override
@@ -82,14 +75,8 @@ public class MainActivity extends AppCompatActivity {
         setContentView(R.layout.activity_main);
         mainViewGroup = findViewById(android.R.id.content);
         findViewById(R.id.review_consents).setOnClickListener(_v -> {
-            try {
-                ccpaConsentLib = buildAndRunConsentLib();
-                ccpaConsentLib.showPm();
-            } catch (ConsentLibException e) {
-                e.printStackTrace();
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
+            ccpaConsentLib = buildAndRunConsentLib();
+            ccpaConsentLib.showPm();
         });
     }
 

--- a/app/src/main/java/com/sourcepoint/test_project/MainActivity.java
+++ b/app/src/main/java/com/sourcepoint/test_project/MainActivity.java
@@ -96,10 +96,8 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onResume() {
         super.onResume();
-        ccpaConsentLib = buildCCPAConsentLib();
-        ccpaConsentLib.run();
-        gdprConsentLib = buildGDPRConsentLib();
-        gdprConsentLib.run();
+        buildCCPAConsentLib().run();
+        buildGDPRConsentLib().run();
     }
 
     @Override
@@ -108,10 +106,8 @@ public class MainActivity extends AppCompatActivity {
         setContentView(R.layout.activity_main);
         mainViewGroup = findViewById(android.R.id.content);
         findViewById(R.id.review_consents).setOnClickListener(_v -> {
-            ccpaConsentLib = buildCCPAConsentLib();
-            ccpaConsentLib.showPm();
-            gdprConsentLib = buildGDPRConsentLib();
-            gdprConsentLib.showPm();
+            buildCCPAConsentLib().showPm();
+            buildGDPRConsentLib().showPm();
         });
     }
 

--- a/app/src/main/java/com/sourcepoint/test_project/MainActivity.java
+++ b/app/src/main/java/com/sourcepoint/test_project/MainActivity.java
@@ -4,9 +4,9 @@ import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 import android.util.Log;
 
-import com.sourcepoint.cmplibrary.CCPAConsentLib;
-import com.sourcepoint.cmplibrary.ConsentLibException;
-import com.sourcepoint.cmplibrary.UserConsent;
+import com.sourcepoint.ccpa_cmplibrary.CCPAConsentLib;
+import com.sourcepoint.ccpa_cmplibrary.ConsentLibException;
+import com.sourcepoint.ccpa_cmplibrary.UserConsent;
 
 public class MainActivity extends AppCompatActivity {
     private static final String TAG = "MainActivity";

--- a/app/src/main/java/com/sourcepoint/test_project/MainActivity.java
+++ b/app/src/main/java/com/sourcepoint/test_project/MainActivity.java
@@ -35,7 +35,6 @@ public class MainActivity extends AppCompatActivity {
     private GDPRConsentLib buildGDPRConsentLib() {
         return GDPRConsentLib.newBuilder(22, "mobile.demo", 2372,"5c0e81b7d74b3c30c6852301",this)
                 .setStagingCampaign(true)
-                .setAuthId("gdpr-test")
                 .setOnConsentUIReady(consentLib -> {
                     showMessageWebView(consentLib.webView);
                     Log.i(TAG, "onConsentUIReady");

--- a/authexample/src/main/java/com/example/authexample/ConsentManager.java
+++ b/authexample/src/main/java/com/example/authexample/ConsentManager.java
@@ -3,10 +3,10 @@ package com.example.authexample;
 import android.app.Activity;
 import android.util.Log;
 
-import com.sourcepoint.cmplibrary.CCPAConsentLib;
-import com.sourcepoint.cmplibrary.Consent;
-import com.sourcepoint.cmplibrary.ConsentLibBuilder;
-import com.sourcepoint.cmplibrary.ConsentLibException;
+import com.sourcepoint.ccpa_cmplibrary.CCPAConsentLib;
+import com.sourcepoint.ccpa_cmplibrary.Consent;
+import com.sourcepoint.ccpa_cmplibrary.ConsentLibBuilder;
+import com.sourcepoint.ccpa_cmplibrary.ConsentLibException;
 
 import java.util.HashSet;
 

--- a/authexample/src/main/java/com/example/authexample/ConsentManager.java
+++ b/authexample/src/main/java/com/example/authexample/ConsentManager.java
@@ -32,8 +32,8 @@ abstract class ConsentManager {
 //                HashSet<Consent> consents = (HashSet) results;
 //                onConsentsReady(consents, consentLib.consentUUID, consentLib.euconsent);
 //            }))
-            .setOnMessageReady(_c -> Log.d(TAG, "Message Ready"))
-            .setOnErrorOccurred(c -> Log.d(TAG, "Error Occurred: "+c.error));
+            .setOnConsentUIReady(_c -> Log.d(TAG, "Message Ready"))
+            .setOnError(c -> Log.d(TAG, "Error Occurred: "+c.error));
     }
 
     void loadMessage(Boolean pm) {

--- a/authexample/src/main/java/com/example/authexample/HomeActivity.java
+++ b/authexample/src/main/java/com/example/authexample/HomeActivity.java
@@ -12,7 +12,7 @@ import android.widget.ArrayAdapter;
 import android.widget.ListView;
 import android.widget.TextView;
 
-import com.sourcepoint.cmplibrary.Consent;
+import com.sourcepoint.ccpa_cmplibrary.Consent;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;

--- a/authexample/src/main/java/com/example/authexample/LoginActivity.java
+++ b/authexample/src/main/java/com/example/authexample/LoginActivity.java
@@ -16,7 +16,7 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ListView;
 
-import com.sourcepoint.cmplibrary.Consent;
+import com.sourcepoint.ccpa_cmplibrary.Consent;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/ccpa_cmplibrary/build.gradle
+++ b/ccpa_cmplibrary/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id "com.jfrog.bintray" version "1.8.4"
 }
 
-def VERSION_NAME = "1.0.1"
+def VERSION_NAME = "1.1.0"
 
 apply plugin: 'com.android.library'
 apply plugin: 'maven-publish'

--- a/ccpa_cmplibrary/src/main/java/com/sourcepoint/ccpa_cmplibrary/CCPAConsentLib.java
+++ b/ccpa_cmplibrary/src/main/java/com/sourcepoint/ccpa_cmplibrary/CCPAConsentLib.java
@@ -14,6 +14,7 @@ import org.json.JSONObject;
 
 import java.io.UnsupportedEncodingException;
 import java.util.HashSet;
+import java.util.UUID;
 
 /**
  * Entry point class encapsulating the Consents a giving user has given to one or several vendors.
@@ -134,8 +135,8 @@ public class CCPAConsentLib {
         // per gdpr framework: https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/852cf086fdac6d89097fdec7c948e14a2121ca0e/In-App%20Reference/Android/app/src/main/java/com/smaato/soma/cmpconsenttooldemoapp/cmpconsenttool/storage/CMPStorage.java
         //sharedPref = PreferenceManager.getDefaultSharedPreferences(activity);
         sharedPref = PreferenceManager.getDefaultSharedPreferences(activity);
-        consentUUID = sharedPref.getString(CONSENT_UUID_KEY, null);
-        metaData = sharedPref.getString(META_DATA_KEY, null);
+        consentUUID = sharedPref.getString(CONSENT_UUID_KEY, UUID.randomUUID().toString());
+        metaData = sharedPref.getString(META_DATA_KEY, "{}");
         webView = buildWebView();
     }
 

--- a/ccpa_cmplibrary/src/main/java/com/sourcepoint/ccpa_cmplibrary/CCPAConsentLib.java
+++ b/ccpa_cmplibrary/src/main/java/com/sourcepoint/ccpa_cmplibrary/CCPAConsentLib.java
@@ -26,10 +26,10 @@ import java.util.HashSet;
 public class CCPAConsentLib {
 
     @SuppressWarnings("WeakerAccess")
-    public static final String CONSENT_UUID_KEY = "consentUUID";
+    public static final String CONSENT_UUID_KEY = "sp.ccpa.consentUUID";
 
     @SuppressWarnings("WeakerAccess")
-    public static final String META_DATA_KEY = "metaData";
+    public static final String META_DATA_KEY = "sp.ccpa.metaData";
     private final String pmId;
 
     private final String PM_BASE_URL = "https://ccpa-inapp-pm.sp-prod.net";

--- a/ccpa_cmplibrary/src/main/java/com/sourcepoint/ccpa_cmplibrary/CCPAConsentLib.java
+++ b/ccpa_cmplibrary/src/main/java/com/sourcepoint/ccpa_cmplibrary/CCPAConsentLib.java
@@ -1,7 +1,6 @@
-package com.sourcepoint.cmplibrary;
+package com.sourcepoint.ccpa_cmplibrary;
 
 import android.app.Activity;
-import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.CountDownTimer;
 import android.preference.PreferenceManager;
@@ -15,8 +14,6 @@ import org.json.JSONObject;
 
 import java.io.UnsupportedEncodingException;
 import java.util.HashSet;
-
-import static android.content.Context.MODE_PRIVATE;
 
 /**
  * Entry point class encapsulating the Consents a giving user has given to one or several vendors.

--- a/ccpa_cmplibrary/src/main/java/com/sourcepoint/ccpa_cmplibrary/Consent.java
+++ b/ccpa_cmplibrary/src/main/java/com/sourcepoint/ccpa_cmplibrary/Consent.java
@@ -1,4 +1,4 @@
-package com.sourcepoint.cmplibrary;
+package com.sourcepoint.ccpa_cmplibrary;
 
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/ccpa_cmplibrary/src/main/java/com/sourcepoint/ccpa_cmplibrary/ConsentLibBuilder.java
+++ b/ccpa_cmplibrary/src/main/java/com/sourcepoint/ccpa_cmplibrary/ConsentLibBuilder.java
@@ -1,4 +1,4 @@
-package com.sourcepoint.cmplibrary;
+package com.sourcepoint.ccpa_cmplibrary;
 
 import android.app.Activity;
 import android.os.Build;

--- a/ccpa_cmplibrary/src/main/java/com/sourcepoint/ccpa_cmplibrary/ConsentLibBuilder.java
+++ b/ccpa_cmplibrary/src/main/java/com/sourcepoint/ccpa_cmplibrary/ConsentLibBuilder.java
@@ -177,35 +177,41 @@ public class ConsentLibBuilder {
         return this;
     }
 
-    public ConsentLibBuilder setAuthId(String authId) throws ConsentLibException.BuildException {
-        this.authId = new EncodedParam("authId", authId);
-        return this;
-    }
+    //TODO implement authId support for CCPA
+//    public ConsentLibBuilder setAuthId(String authId) throws ConsentLibException.BuildException {
+//        this.authId = new EncodedParam("authId", authId);
+//        return this;
+//    }
 
     public ConsentLibBuilder setShowPM(boolean isUserTriggered){
         this.isShowPM = isUserTriggered;
         return this;
     }
 
-    public ConsentLibBuilder setTargetingParam(String key, Integer val)
-            throws ConsentLibException.BuildException  {
-        return setTargetingParam(key, (Object) val);
-    }
+    //TODO implement targetting params support for CCPA
+//    public ConsentLibBuilder setTargetingParam(String key, Integer val)
+//            throws ConsentLibException.BuildException  {
+//        return setTargetingParam(key, (Object) val);
+//    }
+//
+//    public ConsentLibBuilder setTargetingParam(String key, String val)
+//            throws ConsentLibException.BuildException {
+//        return setTargetingParam(key, (Object) val);
+//    }
+//
+//    private ConsentLibBuilder setTargetingParam(String key, Object val) throws ConsentLibException.BuildException {
+//        try {
+//            this.targetingParams.put(key, val);
+//        } catch (JSONException e) {
+//            throw new ConsentLibException
+//                    .BuildException("error parsing targeting param, key: "+key+" value: "+val);
+//        }
+//        return this;
+//    }
 
-    public ConsentLibBuilder setTargetingParam(String key, String val)
-            throws ConsentLibException.BuildException {
-        return setTargetingParam(key, (Object) val);
-    }
-
-    private ConsentLibBuilder setTargetingParam(String key, Object val) throws ConsentLibException.BuildException {
-        try {
-            this.targetingParams.put(key, val);
-        } catch (JSONException e) {
-            throw new ConsentLibException
-                    .BuildException("error parsing targeting param, key: "+key+" value: "+val);
-        }
-        return this;
-    }
+//    private void setTargetingParamsString() throws ConsentLibException {
+//        targetingParamsString = new EncodedParam("targetingParams", targetingParams.toString());
+//    }
 
     /**
      * <b>Optional</b> Sets the DEBUG level.
@@ -220,9 +226,7 @@ public class ConsentLibBuilder {
         return this;
     }
 
-    private void setTargetingParamsString() throws ConsentLibException {
-        targetingParamsString = new EncodedParam("targetingParams", targetingParams.toString());
-    }
+
 
     /**
      * The Android 4.x Browser throws an exception when parsing SourcePoint's javascript.
@@ -240,21 +244,7 @@ public class ConsentLibBuilder {
      * @return CCPAConsentLib | ConsentLibNoOp
      * @throws ConsentLibException.BuildException - if any of the required data is missing or invalid
      */
-    public CCPAConsentLib build() throws ConsentLibException {
-        if(sdkNotSupported()) {
-            throw new ConsentLibException.BuildException(
-                    "CCPAConsentLib supports only API level 19 and above.\n"+
-                            "See https://github.com/SourcePointUSA/android-cmp-app/issues/25 for more information."
-            );
-        }
-
-        try {
-            setTargetingParamsString();
-        } catch (ConsentLibException e) {
-            this.activity = null; // release reference to activity
-            throw new ConsentLibException.BuildException(e.getMessage());
-        }
-
+    public CCPAConsentLib build() {
         return new CCPAConsentLib(this);
     }
 

--- a/ccpa_cmplibrary/src/main/java/com/sourcepoint/ccpa_cmplibrary/ConsentLibBuilder.java
+++ b/ccpa_cmplibrary/src/main/java/com/sourcepoint/ccpa_cmplibrary/ConsentLibBuilder.java
@@ -17,7 +17,7 @@ public class ConsentLibBuilder {
     String mmsDomain, cmpDomain, msgDomain;
     String page = "";
     ViewGroup viewGroup = null;
-    CCPAConsentLib.Callback onAction, onConsentReady, onError, onMessageReady;
+    CCPAConsentLib.Callback onAction, onConsentReady, onError, onConsentUIReady, onConsentUIFinished;
     boolean staging, stagingCampaign, newPM , isShowPM, shouldCleanConsentOnError;
 
     EncodedParam targetingParamsString = null;
@@ -40,7 +40,7 @@ public class ConsentLibBuilder {
             public void run(CCPAConsentLib c) {
             }
         };
-        onAction = onConsentReady = onError = onMessageReady = noOpCallback;
+        onAction = onConsentReady = onError = onConsentUIReady = onConsentUIFinished = noOpCallback;
     }
 
     /**
@@ -102,8 +102,18 @@ public class ConsentLibBuilder {
      * @param callback to be called when the message is ready to be displayed
      * @return ConsentLibBuilder
      */
-    public ConsentLibBuilder setOnMessageReady(CCPAConsentLib.Callback callback) {
-        onMessageReady = callback;
+    public ConsentLibBuilder setOnConsentUIReady(CCPAConsentLib.Callback callback) {
+        onConsentUIReady = callback;
+        return this;
+    }
+
+    /**
+     * Called when the Dialog message is about to be shown
+     * @param callback to be called when the message is ready to be closed
+     * @return ConsentLibBuilder
+     */
+    public ConsentLibBuilder setOnConsentUIFinished(CCPAConsentLib.Callback callback) {
+        onConsentUIFinished = callback;
         return this;
     }
 
@@ -113,7 +123,7 @@ public class ConsentLibBuilder {
      * @return ConsentLibBuilder - the next build step
      * @see ConsentLibBuilder
      */
-    public ConsentLibBuilder setOnErrorOccurred(CCPAConsentLib.Callback callback) {
+    public ConsentLibBuilder setOnError(CCPAConsentLib.Callback callback) {
         onError = callback;
         return this;
     }

--- a/ccpa_cmplibrary/src/main/java/com/sourcepoint/ccpa_cmplibrary/ConsentLibException.java
+++ b/ccpa_cmplibrary/src/main/java/com/sourcepoint/ccpa_cmplibrary/ConsentLibException.java
@@ -1,16 +1,24 @@
 package com.sourcepoint.ccpa_cmplibrary;
 
 public class ConsentLibException extends Exception {
+
+    public String consentLibErrorMessage;
+
     ConsentLibException() { super(); }
-    ConsentLibException(String message) { super(message); }
+    ConsentLibException(Exception e){ super(e); consentLibErrorMessage = "Something went wrong in the consentLib world."; }
+    ConsentLibException(Exception e, String  message){ super(e); consentLibErrorMessage = message;}
+
+    ConsentLibException(String  message){ super(); consentLibErrorMessage = message;}
 
     public static class BuildException extends ConsentLibException {
-        BuildException(String message) { super("Error during CCPAConsentLib build: "+message); }
+        BuildException(Exception e, String message) { super(e, "Error during ConsentLib build: "+message); }
+        BuildException(String message) { super("Error during ConsentLib build: "+message); }
     }
 
     public static class NoInternetConnectionException extends ConsentLibException {}
-    
+
     public static class ApiException extends ConsentLibException {
-        ApiException(String message) { super(message); }
+        ApiException(Exception e, String message) { super(e, "Error due to android API: " + message); }
+        ApiException(String message) { super("Error due to android API: " + message); }
     }
 }

--- a/ccpa_cmplibrary/src/main/java/com/sourcepoint/ccpa_cmplibrary/ConsentLibException.java
+++ b/ccpa_cmplibrary/src/main/java/com/sourcepoint/ccpa_cmplibrary/ConsentLibException.java
@@ -1,4 +1,4 @@
-package com.sourcepoint.cmplibrary;
+package com.sourcepoint.ccpa_cmplibrary;
 
 public class ConsentLibException extends Exception {
     ConsentLibException() { super(); }

--- a/ccpa_cmplibrary/src/main/java/com/sourcepoint/ccpa_cmplibrary/ConsentWebView.java
+++ b/ccpa_cmplibrary/src/main/java/com/sourcepoint/ccpa_cmplibrary/ConsentWebView.java
@@ -1,4 +1,4 @@
-package com.sourcepoint.cmplibrary;
+package com.sourcepoint.ccpa_cmplibrary;
 
 import android.annotation.SuppressLint;
 import android.content.Context;

--- a/ccpa_cmplibrary/src/main/java/com/sourcepoint/ccpa_cmplibrary/EncodedParam.java
+++ b/ccpa_cmplibrary/src/main/java/com/sourcepoint/ccpa_cmplibrary/EncodedParam.java
@@ -1,4 +1,4 @@
-package com.sourcepoint.cmplibrary;
+package com.sourcepoint.ccpa_cmplibrary;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;

--- a/ccpa_cmplibrary/src/main/java/com/sourcepoint/ccpa_cmplibrary/SourcePointClient.java
+++ b/ccpa_cmplibrary/src/main/java/com/sourcepoint/ccpa_cmplibrary/SourcePointClient.java
@@ -1,4 +1,4 @@
-package com.sourcepoint.cmplibrary;
+package com.sourcepoint.ccpa_cmplibrary;
 
 import android.text.TextUtils;
 import android.util.Log;
@@ -12,8 +12,6 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.UnsupportedEncodingException;
-import java.net.URL;
-import java.net.URLEncoder;
 import java.util.HashSet;
 import java.util.UUID;
 

--- a/ccpa_cmplibrary/src/main/java/com/sourcepoint/ccpa_cmplibrary/UserConsent.java
+++ b/ccpa_cmplibrary/src/main/java/com/sourcepoint/ccpa_cmplibrary/UserConsent.java
@@ -1,4 +1,4 @@
-package com.sourcepoint.cmplibrary;
+package com.sourcepoint.ccpa_cmplibrary;
 
 import org.json.JSONArray;
 import org.json.JSONException;

--- a/ccpa_cmplibrary/src/test/java/com/sourcepoint/ccpa_cmplibrary/CCPAConsentLibBuilderTest.java
+++ b/ccpa_cmplibrary/src/test/java/com/sourcepoint/ccpa_cmplibrary/CCPAConsentLibBuilderTest.java
@@ -68,19 +68,19 @@ public class CCPAConsentLibBuilderTest {
 
     @Test
     public void setOnInteractionComplete() {
-        consentLibBuilder.setOnMessageReady(callback);
-        assertEquals(callback, consentLibBuilder.onMessageReady);
+        consentLibBuilder.setOnConsentUIReady(callback);
+        assertEquals(callback, consentLibBuilder.onConsentUIReady);
     }
 
     @Test
     public void setOnMessageReady() {
-        consentLibBuilder.setOnMessageReady(callback);
-        assertEquals(callback, consentLibBuilder.onMessageReady);
+        consentLibBuilder.setOnConsentUIReady(callback);
+        assertEquals(callback, consentLibBuilder.onConsentUIReady);
     }
 
     @Test
     public void setOnErrorOccurred() {
-        consentLibBuilder.setOnErrorOccurred(callback);
+        consentLibBuilder.setOnError(callback);
         assertEquals(callback, consentLibBuilder.onError);
     }
 

--- a/ccpa_cmplibrary/src/test/java/com/sourcepoint/ccpa_cmplibrary/CCPAConsentLibBuilderTest.java
+++ b/ccpa_cmplibrary/src/test/java/com/sourcepoint/ccpa_cmplibrary/CCPAConsentLibBuilderTest.java
@@ -1,4 +1,4 @@
-package com.sourcepoint.cmplibrary;
+package com.sourcepoint.ccpa_cmplibrary;
 
 import android.app.Activity;
 import android.view.ViewGroup;

--- a/ccpa_cmplibrary/src/test/java/com/sourcepoint/ccpa_cmplibrary/CCPAConsentLibTest.java
+++ b/ccpa_cmplibrary/src/test/java/com/sourcepoint/ccpa_cmplibrary/CCPAConsentLibTest.java
@@ -1,15 +1,10 @@
-package com.sourcepoint.cmplibrary;
+package com.sourcepoint.ccpa_cmplibrary;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.preference.PreferenceManager;
 
-import org.junit.Before;
-import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mockito;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.RuntimeEnvironment;
 
 import static org.junit.Assert.assertEquals;
 

--- a/ccpa_cmplibrary/src/test/java/com/sourcepoint/ccpa_cmplibrary/EncodedParamTest.java
+++ b/ccpa_cmplibrary/src/test/java/com/sourcepoint/ccpa_cmplibrary/EncodedParamTest.java
@@ -1,4 +1,4 @@
-package com.sourcepoint.cmplibrary;
+package com.sourcepoint.ccpa_cmplibrary;
 
 import org.junit.Test;
 

--- a/ccpa_cmplibrary/src/test/java/com/sourcepoint/ccpa_cmplibrary/SourcePointClientTest.java
+++ b/ccpa_cmplibrary/src/test/java/com/sourcepoint/ccpa_cmplibrary/SourcePointClientTest.java
@@ -1,33 +1,15 @@
-package com.sourcepoint.cmplibrary;
+package com.sourcepoint.ccpa_cmplibrary;
 
 import com.loopj.android.http.AsyncHttpClient;
-import com.loopj.android.http.ResponseHandlerInterface;
 
-import org.json.JSONException;
-import org.json.JSONObject;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-import java.util.HashSet;
-
-import cz.msebera.android.httpclient.Header;
-
 import static android.os.Build.VERSION_CODES.O;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @RunWith(RobolectricTestRunner.class)


### PR DESCRIPTION
This includes key improvements for both compatibility with gdpr sdk and UI and error callbacks.

Changes:

-> setOnConsentUIReady() and setOnConsentUIFinished() implemented for allowing the user to manipulate the UI life cycle himself

-> module and store key_values renamed for gdpr compatibility

-> no more errors thrown from consentLib, all you need it to listen to to onError call back!

-> example app updated if a working implementation for running latest versions of gdpr and ccpa sdk together