### PR TITLE
Fix concurrency timeout crash

### DIFF
--- a/ccpa_cmplibrary/src/main/java/com/sourcepoint/ccpa_cmplibrary/CCPAConsentLib.java
+++ b/ccpa_cmplibrary/src/main/java/com/sourcepoint/ccpa_cmplibrary/CCPAConsentLib.java
@@ -147,7 +147,7 @@ public class CCPAConsentLib {
             public void onMessageReady() {
                 Log.d("msgReady", "called");
                 if (mCountDownTimer != null) mCountDownTimer.cancel();
-                if(!onMessageReadyCalled) {
+                if(!onMessageReadyCalled && !hasErrorOccurred()) {
                     runOnLiveActivityUIThread(() -> CCPAConsentLib.this.onConsentUIReady.run(CCPAConsentLib.this));
                     onMessageReadyCalled = true;
                 }
@@ -278,9 +278,12 @@ public class CCPAConsentLib {
             @Override
             public void onFailure(ConsentLibException e) {
                 onErrorTask(e);
-
             }
         });
+    }
+
+    private boolean hasErrorOccurred(){
+        return error != null;
     }
 
     private JSONObject paramsToSendConsent() throws JSONException {
@@ -325,8 +328,7 @@ public class CCPAConsentLib {
             @Override
             public void onFinish() {
                 if (!onMessageReadyCalled) {
-                    onConsentUIReady = null;
-                    webView.onError(new ConsentLibException("a timeout has occurred when loading the message"));
+                    onErrorTask(new ConsentLibException("a timeout has occurred when loading the message"));
                 }
             }
         };

--- a/ccpa_cmplibrary/src/main/java/com/sourcepoint/ccpa_cmplibrary/CCPAConsentLib.java
+++ b/ccpa_cmplibrary/src/main/java/com/sourcepoint/ccpa_cmplibrary/CCPAConsentLib.java
@@ -375,10 +375,10 @@ public class CCPAConsentLib {
         cancelCounter();
         runOnLiveActivityUIThread(() -> CCPAConsentLib.this.onConsentUIFinished.run(CCPAConsentLib.this));
         runOnLiveActivityUIThread(() -> CCPAConsentLib.this.onError.run(CCPAConsentLib.this));
-        resetCallBacks();
+        resetCallbacks();
     }
 
-    private void resetCallBacks(){
+    private void resetCallbacks(){
         onAction = onError = onConsentUIFinished = onConsentReady = onConsentUIReady = c -> {};
     }
 

--- a/ccpa_cmplibrary/src/main/java/com/sourcepoint/ccpa_cmplibrary/CCPAConsentLib.java
+++ b/ccpa_cmplibrary/src/main/java/com/sourcepoint/ccpa_cmplibrary/CCPAConsentLib.java
@@ -66,8 +66,9 @@ public class CCPAConsentLib {
     private final String property;
     private final int accountId, propertyId;
     private final ViewGroup viewGroup;
-    private final Callback onAction, onConsentReady, onError;
+    private Callback onAction, onConsentReady, onError;
     private Callback onConsentUIReady, onConsentUIFinished;
+
     private final boolean weOwnTheView, isShowPM;
 
     //default time out changes
@@ -120,6 +121,7 @@ public class CCPAConsentLib {
         isShowPM = b.isShowPM;
         onAction = b.onAction;
         onConsentReady = b.onConsentReady;
+
         onError = b.onError;
         onConsentUIReady = b.onConsentUIReady;
         onConsentUIFinished = b.onConsentUIFinished;
@@ -147,7 +149,7 @@ public class CCPAConsentLib {
             public void onMessageReady() {
                 Log.d("msgReady", "called");
                 if (mCountDownTimer != null) mCountDownTimer.cancel();
-                if(!onMessageReadyCalled && !hasErrorOccurred()) {
+                if(!onMessageReadyCalled) {
                     runOnLiveActivityUIThread(() -> CCPAConsentLib.this.onConsentUIReady.run(CCPAConsentLib.this));
                     onMessageReadyCalled = true;
                 }
@@ -373,6 +375,11 @@ public class CCPAConsentLib {
         cancelCounter();
         runOnLiveActivityUIThread(() -> CCPAConsentLib.this.onConsentUIFinished.run(CCPAConsentLib.this));
         runOnLiveActivityUIThread(() -> CCPAConsentLib.this.onError.run(CCPAConsentLib.this));
+        resetCallBacks();
+    }
+
+    private void resetCallBacks(){
+        onAction = onError = onConsentUIFinished = onConsentReady = onConsentUIReady = c -> {};
     }
 
     private void cancelCounter(){


### PR DESCRIPTION
So basically now setting all callback to c -> {} in case there is an error. No nullPointers 🙌 