### PR TITLE
Sp 4221 implement retry logic

### DIFF
--- a/AutomationFramework/README.md
+++ b/AutomationFramework/README.md
@@ -1,32 +1,142 @@
 ## Automation Framework
 
-## Prerequisites Installations:
 
-1. <b>`JAVA 1.8`</b> - Install Java and set the JAVA_HOME path on your machine. Add $JAVA_HOME/bin in PATH variable.
-2. <b>`Node & NPM`</b> - Download & install node. you can refer `https://nodejs.org/en/download/`.
-3. <b>`Gradle`</b> - Install Gradle and set the GRADLE_HOME on your machine. Add $GRADLE_HOME/bin in PATH variable.
-4. <b>`Android`</b> - Install Android Studio & set $ANDROID_HOME on your machine.
-5. <b>`iOS`</b> - Install XCode on your machine.
-6. <b> Allure Report - Install Allure Report library on your machine. Please follow below link to install it on MAC.
-Similarly install allure-report installer on your respective machine. https://docs.qameta.io/allure/#_installing_a_commandline    
+## Prerequisites and Setup
 
-## Appium Setup:
+JAVA 1.8
+- Install Java 
 
-- <b>`Install Appium`</b> 
-``` 
- $ sudo npm install -g appium@1.17.0
-```
-- <b>`Appium Doctor`</b> - which is used to see if the appium setup is correctly done or not. Run it and fix the issues as per that.<br>
-``` 
- $ sudo npm install -g appium-doctor
- $ appium-doctor
-```
- 
-## How To Run Tests:
+        https://www.oracle.com/java/technologies/javase/javase-jdk8-downloads.html
+And set environmental variables
 
-1. Get the code on your machine
-2. Go to the folder AUtomationFramework folder on terminal
-```
-$ gradle clean build
-$ java -jar build/libs/AutomationFramework-1.0-SNAPSHOT.jar
+On MAC:
+- Set JAVA_HOME and $JAVA_HOME/bin in PATH variable on MAC OS
+
+    export JAVA_HOME=/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/$
+
+    export PATH=$PATH:$JAVA_HOME/bin
+
+On Windows:
+
+    https://docs.oracle.com/en/database/oracle/r-enterprise/1.5.1/oread/creating-and-modifying-environment-variables-on-windows.html#GUID-DD6F9982-60D5-48F6-8270-A27EC53807D0
+
+Install Gradle
+
+On MAC:
+Install Homebrew
+
+    https://docs.brew.sh/Installation
+
+    $ ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+
+Install Node & NPM
+
+    https://www.npmjs.com/get-npm
+
+Install Gradle
+
+    $ brew install gradle
+
+- Set the GRADLE_HOME and $GRADLE_HOME/bin in PATH variable on MAC OS
+
+	export GRADLE=/usr/local/Cellar/gradle/6.5
+	export PATH=$PATH:$GRADLE_HOME/bin
+
+On Windows:
+
+    https://gradle.org/install/
+    
+Install Android Studio
+
+    https://developer.android.com/studio
+On MAC:
+
+- Set $ANDROID_HOME and update PATH variables as below on your machine.
+
+    export ANDROID_HOME=/Users/*****/Library/Android/sdk
+    export PATH=$ANDROID_HOME/platform-tools:$PATH
+    export PATH=$ANDROID_HOME/tools:$PATH
+    export PATH=$ANDROID_HOME/bin:$PATH
+    export PATH=$ANDROID_HOME/platform-tools/adb:$PATH
+    export PATH=$ANDROID_HOME/build-tools:$PATH
+    
+On Windows:
+
+1. Right-click on ‘My Computer’ and select Properties. Go to Advanced system settings and select ‘Environmental Variables’ option.
+2. Under the User Variable table, click New to open New User Variable dialog.
+3. Put ANDROID_HOME as Variable name and provide the path of the SDK folder next to Variable value.
+4. Click OK to close the dialog 
+5. Go to the folder where SDK has been installed.
+6. Inside the SDK folder look for ‘tools’ and ‘platform-tools’ folder.
+7. Copy the path for both tools and platform-tools.
+8. Open ‘Environmental Variables’ dialog box.
+9. Go to System Variables table and locate the Path variable.
+10. Edit the path variable from ‘Edit system Variables’ dialog box.
+11. Add the ‘tools’ and platform-tools’ folder’s full path
+
+Install Appium 
+
+    $ sudo npm install -g appium@1.17.0
+
+Install appium doctor
+
+Appium Doctor which is used to see if the appium setup is correctly done or not. Run it and fix the issues as per that
+
+    $ sudo npm install -g appium-doctor
+    $ appium-doctor
+
+How To Run Tests:
+
+
+1. Launch required emulator or connect real device on which you want tests should run
+2. Start appium server from terminal or command prompt (In next phase will add code to start and stop appium server from framework itself)
+
+        $ appium
+
+3. Get the code on your machine
+4. Open androidDevice.json file (path: AutomationFramework/src/main/resources)
+5. Edit and Save device details 
+For running on emulator update only platformVersion as per the emulator which is launched
+
+          "name": "emulator-5554",
+          "deviceName": "emulator-5554",
+          "platformName": "Android",
+          "platformVersion": "10",				
+          "automationName": "UIAutomator2",
+          "packageName": "com.sourcepointccpa.app",
+          "activity": "com.sourcepointccpa.app.ui.SplashScreenActivity",
+          "app": "CCPA-MetaApp.apk”    			 
+
+For running on real device update values for name, deviceName, platformVersion as per the connected device
+
+        "name": "emulator-5554",				
+        "deviceName": "emulator-5554",			
+        "platformName": "Android",
+        "platformVersion": "10",				
+        "automationName": "UIAutomator2",
+        "packageName": "com.sourcepointccpa.app",
+        "activity": "com.sourcepointccpa.app.ui.SplashScreenActivity",
+        "app": "CCPA-MetaApp.apk" 			
+
+6.  Edit testing.xml, if device details like nam or deviceName updated in above file
+7.  Add application under test .apk file under /src/main/resources folder
+8. Build the JAR and run it from terminal 
+
+Go to project root directory "AutomationFramework"
+
+        $ gradle clean build
+        $ java -jar build/libs/AutomationFramework-1.0-SNAPSHOT.jar
+
+Allure Report
+
+Install Allure Report library on your machine. Please follow below link to install it on MAC.
+Similarly install allure-report installer on your respective machine.  
+
+    https://docs.qameta.io/allure/#_installing_a_commandline
+Once test execution is complete, allure-results directory gets generated. I assume you have already installed allure on your machine. If not, install it. If yes, run below command to see the report.
+
+        $ allure serve <allure-results path>
+
+
+
 

--- a/AutomationFramework/src/main/java/org/framework/helpers/Page.java
+++ b/AutomationFramework/src/main/java/org/framework/helpers/Page.java
@@ -8,6 +8,7 @@ import io.appium.java_client.AppiumDriver;
 public class Page {
 
 	WebDriver driver;
+	public int timeOutInSeconds = 30;
 
     public void clickElement(WebElement element) {
         element.click();

--- a/AutomationFramework/src/main/java/org/framework/pageObjects/ConsentViewPage.java
+++ b/AutomationFramework/src/main/java/org/framework/pageObjects/ConsentViewPage.java
@@ -40,34 +40,9 @@ public class ConsentViewPage extends Page {
 		PageFactory.initElements(new AppiumFieldDecorator(driver), this);
 		Thread.sleep(1000);
 	}
-//	protected Report reporter = null;
-
-	@WithTimeout(time = 30, chronoUnit = ChronoUnit.SECONDS)
-	@AndroidFindBy(xpath = "//android.view.View[contains(@resource-id,'sp_message_panel_id')]")
-	public WebElement ConsentMessageView;
-
-	@WithTimeout(time = 30, chronoUnit = ChronoUnit.SECONDS)
-	@AndroidFindBy(xpath = "//android.view.View[@index='0']")
-	public WebElement ConsentMessageTitleText;
-
-	@WithTimeout(time = 30, chronoUnit = ChronoUnit.SECONDS)
-	@AndroidFindBy(xpath = "//android.view.View[@index='1']")
-	public WebElement ConsentMessageBodyText;
 
 	@AndroidFindBy(xpath = "//android.view.View[@text='X']")
 	public WebElement CloseButton;
-
-	@AndroidFindBy(xpath = "//android.widget.Button[@text='Continue']")
-	public WebElement ContinueButton;
-
-	@AndroidFindBy(xpath = "//android.widget.Button[@text='Accept all cookies']")
-	public WebElement AcceptallCookiesButton;
-
-	@AndroidFindBy(xpath = "//android.widget.Button[@content-desc='Accept All cookies']")
-	public WebElement AcceptAllCookiesButton;
-
-	@AndroidFindBy(xpath = "//android.widget.Button[@text='Reject all cookies']")
-	public WebElement RejectAllCookiesButton;
 
 	@AndroidFindBy(xpath = "//android.widget.Button[@text='Show Purposes']")
 	public WebElement ShowPurposesButton;
@@ -75,14 +50,6 @@ public class ConsentViewPage extends Page {
 	@WithTimeout(time = 80, chronoUnit = ChronoUnit.SECONDS)
 	@AndroidFindBy(xpath = "(//android.view.View)")
 	public List<WebElement> ConsentMessage;
-
-	@WithTimeout(time = 50, chronoUnit = ChronoUnit.SECONDS)
-	@AndroidFindBy(id = "android:id/message")
-	public WebElement ErrorMessageView;
-
-	@WithTimeout(time = 50, chronoUnit = ChronoUnit.SECONDS)
-	@AndroidFindBy(id = "android:id/message")
-	public List<WebElement> WrongCampaignErrorText;
 
 	@AndroidFindBy(id = "android:id/button2")
 	public WebElement ShowSiteInfoButton;
@@ -121,7 +88,6 @@ public class ConsentViewPage extends Page {
 						.findElement(By.xpath("//android.widget.Button[@text='" + buttonText + "']"));
 			} else if (button.getAttribute("content-desc") != null
 					&& button.getAttribute("content-desc").equals(buttonText)) {
-				System.out.println("testing");
 				eleButton = (WebElement) driver
 						.findElement(By.xpath("//android.widget.Button[@content-desc='" + buttonText + "']"));
 			}
@@ -129,86 +95,19 @@ public class ConsentViewPage extends Page {
 		return eleButton;
 	}
 
-	public void loadTime() {
-		try {
-
-			long startTime = System.currentTimeMillis();
-			new WebDriverWait(driver, 120).until(ExpectedConditions.presenceOfElementLocated(
-					By.xpath("//android.webkit.WebView[contains(@text,'Notice Message App')]")));
-			// new WebDriverWait(driver,
-			// 60).until(ExpectedConditions.presenceOfElementLocated(By.xpath("//android.widget.Button[contains(@text,'Privacy
-			// Setting')]")));
-			long endTime = System.currentTimeMillis();
-			long totalTime = endTime - startTime;
-			System.out.println("**** Total Message Load Time: " + totalTime + " milliseconds");
-		} catch (Exception ex) {
-			System.out.println(ex);
-			throw ex;
-		}
-
-	}
-
-	public void scrollAndClick(String text) throws InterruptedException {
-		driver.findElement(MobileBy.AndroidUIAutomator(
-				"new UiScrollable(new UiSelector().scrollable(true).instance(0)).scrollIntoView(new UiSelector().textContains(\""
-						+ text + "\").instance(0))"))
-				.click();
-	}
-
-	public void scrollDown() {
-		Dimension dimension = driver.manage().window().getSize();
-
-		Double scrollHeightStart = dimension.getHeight() * 0.5;
-		int scrollStart = scrollHeightStart.intValue();
-
-		Double scrollHeightEnd = dimension.getHeight() * 0.8;
-		int scrollEnd = scrollHeightEnd.intValue();
-
-		new TouchAction((PerformsTouchActions) driver).press(PointOption.point(0, scrollStart))
-				.waitAction(WaitOptions.waitOptions(Duration.ofSeconds(2))).moveTo(PointOption.point(0, scrollEnd))
-				.release().perform();
-	}
-
 	ArrayList<String> consentMsg = new ArrayList<String>();
 
-	ArrayList<String> expectedList = new ArrayList<String>();
-
-	public void expectedList() {
-		expectedList.add("");
-		expectedList.add("");
-	}
-
 	public ArrayList<String> getConsentMessageDetails() throws InterruptedException {
-		 Thread.sleep(5000);
-		new WebDriverWait(driver, 120).until(ExpectedConditions
-				.presenceOfElementLocated(By.xpath("//android.webkit.WebView[contains(@text,'Notice Message App')]")));
-
+		
+		WebElement button = eleButton("Privacy Settings");
+		waitForElement(button, timeOutInSeconds);
+		
 		for (WebElement msg : ConsentMessage) {
 			consentMsg.add(msg.getText());
-			// consentMsg.add(msg.getAttribute("value"));
 		}
 		return consentMsg;
 	}
 
-	public void getLocation() {
-		for (WebElement msg : ConsentMessage) {
-			Point point = msg.getLocation();
-			TouchAction touchAction = new TouchAction((PerformsTouchActions) driver);
-			System.out.println("******************");
-			System.out.println((point.x) + (msg.getSize().getWidth()));
-			System.out.println((point.y) + (msg.getSize().getWidth()));
-			System.out.println("******************");
-		}
-	}
-
-	public String verifyWrongCampaignError() throws InterruptedException {
-		Thread.sleep(3000);
-		try {
-			return WrongCampaignErrorText.get(WrongCampaignErrorText.size() - 1).getText();
-		} catch (Exception e) {
-			throw e;
-		}
-	}
 
 	public void waitForElement(WebElement ele, int timeOutInSeconds) {
 		WebDriverWait wait = new WebDriverWait(driver, timeOutInSeconds);

--- a/AutomationFramework/src/main/java/org/framework/pageObjects/NewSitePage.java
+++ b/AutomationFramework/src/main/java/org/framework/pageObjects/NewSitePage.java
@@ -42,13 +42,6 @@ public class NewSitePage extends Page {
 	}
 
 	@WithTimeout(time = 30, chronoUnit = ChronoUnit.SECONDS)
-	@AndroidFindBy(id = "com.sourcepointccpa.app:id/toolbar_title")
-	public WebElement CCPANewSitePageHeader;
-
-	@AndroidFindBy(xpath = "//android.widget.TextView[@text='Account ID")
-	public WebElement AccountIDLabel;
-
-	@WithTimeout(time = 30, chronoUnit = ChronoUnit.SECONDS)
 	@AndroidFindBy(id = "com.sourcepointccpa.app:id/action_saveProperty")
 	public WebElement CCPASaveButton;
 
@@ -102,7 +95,6 @@ public class NewSitePage extends Page {
 
 			touchAction.tap(PointOption.point(point.x + 20, point.y + 20)).perform();
 		}
-		Thread.sleep(3000);
 	}
 
 	public void addTargetingParameter(WebElement paramKey, WebElement paramValue, String key, String value)
@@ -117,50 +109,9 @@ public class NewSitePage extends Page {
 		((HidesKeyboard) driver).hideKeyboard();
 	}
 
-	public String getError() throws InterruptedException {
-		boolean check = false;
-		// waitForElement(ErrorMessage, 10);
-		Thread.sleep(5000);
-		int i = ErrorMessage.size();
-
-		String errorMsg = ErrorMessage.get(ErrorMessage.size() - 1).getText();
-		return errorMsg;
-	}
-
-	public boolean verifyError() throws InterruptedException {
-		boolean check = false;
-		// waitForElement(ErrorMessage, 10);
-		Thread.sleep(3000);
-		int i = ErrorMessage.size();
-
-		String errorMsg = ErrorMessage.get(ErrorMessage.size() - 1).getText();
-		if (errorMsg.equals("Please enter targeting parameter key and value")) {
-			check = true;
-		}
-		return check;
-	}
-
-//	public boolean verifyError() {
-//		return paramFound;
-//
-//	}
-
 	public void waitForElement(WebElement ele, int timeOutInSeconds) {
 		WebDriverWait wait = new WebDriverWait(driver, timeOutInSeconds);
 		wait.until(ExpectedConditions.visibilityOf(ele));
 	}
 
-	public boolean verifyErrorMsg(String udid) throws InterruptedException {
-		boolean check = false;
-		// waitForElement(ErrorMessage, 10);
-		Thread.sleep(3000);
-		int i = ErrorMessage.size();
-
-		String errorMsg = ErrorMessage.get(ErrorMessage.size() - 1).getText();
-
-		if (errorMsg.equals("Please enter property details")) {
-			check = true;
-		}
-		return check;
-	}
 }

--- a/AutomationFramework/src/main/java/org/framework/pageObjects/PrivacyManagerPage.java
+++ b/AutomationFramework/src/main/java/org/framework/pageObjects/PrivacyManagerPage.java
@@ -56,14 +56,15 @@ public class PrivacyManagerPage extends Page {
 	public WebElement ccpa_AcceptAllButton;
 
 	@WithTimeout(time = 30, chronoUnit = ChronoUnit.SECONDS)
-	@AndroidFindBy(xpath = "//android.widget.Button[@text='Save & Exit']")
+	@AndroidFindBy(xpath = "//andro"
+			+ "id.widget.Button[@text='Save & Exit']")
 	public WebElement ccpa_SaveAndExitButton;
 
-	@WithTimeout(time = 50, chronoUnit = ChronoUnit.SECONDS)
+	@WithTimeout(time = 30, chronoUnit = ChronoUnit.SECONDS)
 	@AndroidFindBy(xpath = "//android.view.View[@text='Reject All']")
 	public WebElement ccpa_RejectAllButton;
 
-	@WithTimeout(time = 50, chronoUnit = ChronoUnit.SECONDS)
+	@WithTimeout(time = 30, chronoUnit = ChronoUnit.SECONDS)
 	@AndroidFindBy(xpath = "//android.widget.Button[@text='Cancel']")
 	public WebElement ccpa_CancelButton;
 
@@ -75,32 +76,18 @@ public class PrivacyManagerPage extends Page {
 				"new UiScrollable(new UiSelector().scrollable(true).instance(0)).scrollIntoView(new UiSelector().textContains(\""
 						+ text + "\").instance(0))"))
 				.click();
-
-	}
-
-	public void loadTime() {
-		long startTime = System.currentTimeMillis();
-		new WebDriverWait(driver, 60).until(
-				ExpectedConditions.presenceOfElementLocated(By.xpath("//android.widget.Button[@text='Cancel']")));
-		long endTime = System.currentTimeMillis();
-		long totalTime = endTime - startTime;
-		System.out.println("**** Total Privacy Manager Load Time: " + totalTime + " milliseconds");
 	}
 
 	boolean privacyManageeFound = false;
 
 	public boolean isPrivacyManagerViewPresent() throws InterruptedException {
-		Thread.sleep(3000);
-		new WebDriverWait(driver, 120).until(
-				ExpectedConditions.presenceOfElementLocated(By.xpath("//android.widget.Button[@text='Cancel']")));
-
 		try {
+			waitForElement(ccpa_SaveAndExitButton, timeOutInSeconds);		
 			if (driver.findElements(By.xpath("//*[@class='android.webkit.WebView']")).size() > 0)
 				privacyManageeFound = true;
 
 		} catch (Exception e) {
 			privacyManageeFound = false;
-			throw e;
 		}
 		return privacyManageeFound;
 	}
@@ -110,5 +97,11 @@ public class PrivacyManagerPage extends Page {
 		return eleButton;
 
 	}
+	
+	public void waitForElement(WebElement ele, int timeOutInSeconds) {
+		WebDriverWait wait = new WebDriverWait(driver, timeOutInSeconds);
+		wait.until(ExpectedConditions.visibilityOf(ele));
+	}
+
 
 }

--- a/AutomationFramework/src/main/java/org/framework/pageObjects/SiteDebugInfoPage.java
+++ b/AutomationFramework/src/main/java/org/framework/pageObjects/SiteDebugInfoPage.java
@@ -29,10 +29,6 @@ public class SiteDebugInfoPage {
 		Thread.sleep(1000);
 	}
 
-	// @WithTimeout(time = 30, unit = TimeUnit.SECONDS)
-	@AndroidFindBy(id = "com.sourcepointccpa.app:id/toolbar_title")
-	public WebElement CCPASiteDebugInfoPageTitle;
-
 	@WithTimeout(time = 30, chronoUnit = ChronoUnit.SECONDS)
 	@AndroidFindBy(id = "com.sourcepointccpa.app:id/tvConsentUUID")
 	public WebElement CCPAConsentUUID;

--- a/AutomationFramework/src/main/java/org/framework/pageObjects/SiteListPage.java
+++ b/AutomationFramework/src/main/java/org/framework/pageObjects/SiteListPage.java
@@ -89,16 +89,19 @@ public class SiteListPage extends Page {
 
 	boolean siteFound = false;
 
-	public boolean isSitePressent_gdpr(String siteName, String udid, List<WebElement> siteList)
-			throws InterruptedException {
+	public boolean isSitePressent_ccpa(String siteName) throws InterruptedException {
 
 		siteFound = false;
-
-		if (driver.findElement(By.xpath("//XCUIElementTypeStaticText[@name='propertyCell']")).getText()
-				.equals(siteName)) {
-			siteFound = true;
+		try {
+		if (driver.findElements(By.id("com.sourcepointccpa.app:id/propertyNameTextView")).size() > 0) {
+			if (driver.findElement(By.id("com.sourcepointccpa.app:id/propertyNameTextView")).getText()
+					.equals(siteName)) {
+				siteFound = true;
+			}
 		}
-		System.out.println(siteFound);
+		}catch(Exception e) {
+			siteFound = false;
+		}
 		return siteFound;
 	}
 
@@ -109,33 +112,29 @@ public class SiteListPage extends Page {
 
 	public void tapOnSite_ccpa(String siteName, List<WebElement> siteList) throws InterruptedException {
 		driver.findElement(By.id("com.sourcepointccpa.app:id/propertyNameTextView")).click();
-		Thread.sleep(8000);
-
 	}
 
 	public void swipeHorizontaly_ccpa(String siteName) throws InterruptedException {
-		System.out.println("Swipe on " + siteName);
-		WebElement aa = driver.findElement(By.id("com.sourcepointccpa.app:id/propertyNameTextView"));
+		WebElement ele = driver.findElement(By.id("com.sourcepointccpa.app:id/propertyNameTextView"));
+		waitForElement(ele, timeOutInSeconds);
 
-		Point point = aa.getLocation();
+		Point point = ele.getLocation();
 		TouchAction action = new TouchAction((PerformsTouchActions) driver);
 
-		int[] rightTopCoordinates = { aa.getLocation().getX() + aa.getSize().getWidth(), aa.getLocation().getY() };
-		int[] leftTopCoordinates = { aa.getLocation().getX(), aa.getLocation().getY() };
+		int[] rightTopCoordinates = { ele.getLocation().getX() + ele.getSize().getWidth(), ele.getLocation().getY() };
+		int[] leftTopCoordinates = { ele.getLocation().getX(), ele.getLocation().getY() };
 		action.press(PointOption.point(rightTopCoordinates[0] - 1, rightTopCoordinates[1] + 1))
 				.waitAction(WaitOptions.waitOptions(Duration.ofMillis(3000)))
 				.moveTo(PointOption.point(leftTopCoordinates[0] + 1, leftTopCoordinates[1] + 1)).release().perform();
-
-		Thread.sleep(8000);
 	}
 
-	public void waitForElement(WebElement ele, int timeOutInSeconds) {
+	public void waitForElement(WebElement ele, int timeOutInSeconds) {;
 		WebDriverWait wait = new WebDriverWait(driver, timeOutInSeconds);
 		wait.until(ExpectedConditions.visibilityOf(ele));
 	}
 
-	public boolean verifyDeleteSiteMessage(String udid) {
-		return ErrorMessage.get(ErrorMessage.size() - 1).getText().contains("Are you sure you want to");
+	public boolean verifyDeleteSiteMessage() {
+		return ErrorMessage.get(ErrorMessage.size() - 1).getText().contains("Do you want to delete this property?");
 
 	}
 

--- a/AutomationFramework/src/main/java/org/framework/retryAnalyzer/RetryAnalyzer.java
+++ b/AutomationFramework/src/main/java/org/framework/retryAnalyzer/RetryAnalyzer.java
@@ -1,0 +1,20 @@
+package org.framework.retryAnalyzer;
+
+import org.testng.IRetryAnalyzer;
+import org.testng.ITestResult;
+
+public class RetryAnalyzer implements IRetryAnalyzer {
+
+	private int retryCount = 0;
+	private static final int maxRetryCount = 3;
+
+	@Override
+	public boolean retry(ITestResult result) {
+		if (retryCount < maxRetryCount) {
+			retryCount++;
+			return true;
+		}
+		return false;
+	}
+
+}

--- a/AutomationFramework/src/main/java/org/framework/retryAnalyzer/RetryListener.java
+++ b/AutomationFramework/src/main/java/org/framework/retryAnalyzer/RetryListener.java
@@ -1,0 +1,21 @@
+package org.framework.retryAnalyzer;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+
+import org.testng.IAnnotationTransformer;
+import org.testng.IRetryAnalyzer;
+import org.testng.annotations.ITestAnnotation;
+
+public class RetryListener implements IAnnotationTransformer {
+
+	@Override
+	public void transform(ITestAnnotation annotation, Class testClass, Constructor testConstructor, Method testMethod) {
+		// TODO Auto-generated method stub
+		IRetryAnalyzer retry = annotation.getRetryAnalyzer();
+		if (retry == null) {
+			annotation.setRetryAnalyzer(RetryAnalyzer.class);
+		}
+	}
+
+}

--- a/AutomationFramework/src/main/java/tests/CCPA_MetaAppTests.java
+++ b/AutomationFramework/src/main/java/tests/CCPA_MetaAppTests.java
@@ -14,6 +14,8 @@ import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 import org.testng.asserts.SoftAssert;
 
+import io.qameta.allure.Description;
+
 @Listeners({ TestListener.class })
 public class CCPA_MetaAppTests extends BaseTest {
 
@@ -59,28 +61,19 @@ public class CCPA_MetaAppTests extends BaseTest {
 		return expectedAnotherCAMsg;
 	}
 
-	/**
-	 * Given the account id 808 and site name ccpa.automation.testing.com When user
-	 * add targeting parameter as region/ca Then the message with expected title
-	 * will displayed with Reject all and Privacy Settings buttons When user click
-	 * on Privacy Settings button Then user will see Privacy Manager screen When
-	 * user click on Cancel button Then user will navigate back to the consent
-	 * message
-	 */
-
 	@Test(groups = { "CCPASDKTests" }, priority = 1)
+	@Description("Given user submit valid property details and tap on Save Then expected\n"
+			+ "	 consent should display When user navigate to Privacy Manager and click on Cancel button Then user\n"
+			+ "	 will navigate back to the consent message")
 	public void CheckCancleFromPrivacyManager() throws InterruptedException {
-
+		logMessage("CheckCancleFromPrivacyManager - \" + String.valueOf(Thread.currentThread().getId())");
 		SoftAssert softAssert = new SoftAssert();
 		setExpectedCAMsg();
-
 		String key = "region";
 		String value = "ca";
 		try {
-			System.out.println("***************** Test execution start *****************");
-			System.out.println("CheckCancleFromPrivacyManager - " + String.valueOf(Thread.currentThread().getId()));
-
 			MobilePageWrapper mobilePageWrapper = new MobilePageWrapper(driver);
+			logMessage("Enter property details....");
 			mobilePageWrapper.siteListPage.CCPAAddButton.click();
 			mobilePageWrapper.newSitePage.CCPAAccountID.sendKeys(accountId);
 			mobilePageWrapper.newSitePage.CCPASiteId.sendKeys(siteID);
@@ -92,19 +85,24 @@ public class CCPA_MetaAppTests extends BaseTest {
 			mobilePageWrapper.newSitePage.CCPAParameterAddButton.click();
 
 			mobilePageWrapper.newSitePage.CCPASaveButton.click();
+			logMessage("Check for message and tap on Privacy Manager button");
+
 			ArrayList<String> consentMessage = mobilePageWrapper.consentViewPage.getConsentMessageDetails();
-			softAssert.assertTrue(consentMessage.containsAll(expectedCAMsg));
+			softAssert.assertTrue(consentMessage.containsAll(expectedCAMsg), "Expected consent message not displayed");
+			logMessage("Verify Privacy Manager displayed");
 
 			mobilePageWrapper.consentViewPage.eleButton("Privacy Settings").click();
+			logMessage("Tap on Cancel and verify user navigate back to the message");
 
-			softAssert.assertTrue(mobilePageWrapper.privacyManagerPage.isPrivacyManagerViewPresent());
+			softAssert.assertTrue(mobilePageWrapper.privacyManagerPage.isPrivacyManagerViewPresent(),
+					"Privacy Manager not displayed");
 			mobilePageWrapper.privacyManagerPage.ccpa_CancelButton.click();
 
 			ArrayList<String> consentMessage1 = mobilePageWrapper.consentViewPage1.getConsentMessageDetails();
-			softAssert.assertTrue(consentMessage1.containsAll(expectedCAMsg));
+			softAssert.assertTrue(consentMessage1.containsAll(expectedCAMsg), "Expected message not displayed");
 
 		} catch (Exception e) {
-			System.out.println(e);
+			logMessage("Exception: " + e);
 			throw e;
 		} finally {
 			softAssert.assertAll();
@@ -112,19 +110,21 @@ public class CCPA_MetaAppTests extends BaseTest {
 	}
 
 	@Test(groups = { "CCPASDKTests" }, priority = 2)
+	@Description("Given user submit valid property details and tap on Save Then expected\n"
+			+ "	 consent message should display When user select Reject all Then user will\n"
+			+ "	 navigate to Site Info screen showing ConsentUUID and no EUConsent and with no\n"
+			+ "	 Vendors & Purpose Consents When user navigate back & tap on the site name and\n"
+			+ "	 select MANAGE PREFERENCES button from consent message view Then he/she will\n"
+			+ "	 see all vendors & purposes as selected")
 	public void CheckConsentOnRejectAllFromConsentView() throws InterruptedException {
-
+		logMessage("CheckConsentOnRejectAllFromMessage - " + String.valueOf(Thread.currentThread().getId()));
 		SoftAssert softAssert = new SoftAssert();
 		setExpectedCAMsg();
-
 		String key = "region";
 		String value = "ca";
 		try {
-			System.out.println("***************** Test execution start *****************");
-			System.out.println(
-					"CheckConsentOnRejectAllFromConsentView - " + String.valueOf(Thread.currentThread().getId()));
-
 			MobilePageWrapper mobilePageWrapper = new MobilePageWrapper(driver);
+			logMessage("Enter property details");
 			mobilePageWrapper.siteListPage.CCPAAddButton.click();
 			mobilePageWrapper.newSitePage.CCPAAccountID.sendKeys(accountId);
 			mobilePageWrapper.newSitePage.CCPASiteId.sendKeys(siteID);
@@ -136,33 +136,37 @@ public class CCPA_MetaAppTests extends BaseTest {
 			mobilePageWrapper.newSitePage.CCPAParameterAddButton.click();
 			mobilePageWrapper.newSitePage.CCPASaveButton.click();
 
+			logMessage("Check for message and tap on Reject All");
+
 			ArrayList<String> consentMessage = mobilePageWrapper.consentViewPage.getConsentMessageDetails();
-			softAssert.assertTrue(consentMessage.containsAll(expectedCAMsg));
+			softAssert.assertTrue(consentMessage.containsAll(expectedCAMsg), "Expected message not displayed");
 
 			mobilePageWrapper.consentViewPage.eleButton("Reject All").click();
+			logMessage("Get consent information : ConsentUUID: "
+					+ mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID.getText());
 
 			softAssert.assertNotEquals(mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID.getText(),
 					"ConsentUUID not available");
-//				softAssert.assertTrue(mobilePageWrapper.siteDebugInfoPage
-//						.checkForNoPurposeConsentData(mobilePageWrapper.siteDebugInfoPage.CCPAConsentNotAvailable));
-			ArrayList<String> consentData = mobilePageWrapper.siteDebugInfoPage
-					.storeConsent(mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID);
-
 			mobilePageWrapper.siteDebugInfoPage.BackButton.click();
+			logMessage("Tap on the property again and navigate to PM");
 
-			softAssert.assertEquals(mobilePageWrapper.siteListPage.CCPASiteName.getText(), siteName);
+			softAssert.assertEquals(mobilePageWrapper.siteListPage.CCPASiteName.getText(), siteName,
+					"Property not present");
 			mobilePageWrapper.siteListPage.tapOnSite_ccpa(siteName, mobilePageWrapper.siteListPage.CCPASiteList);
 
 			ArrayList<String> consentMessage1 = mobilePageWrapper.consentViewPage.getConsentMessageDetails();
 			softAssert.assertTrue(consentMessage1.containsAll(expectedCAMsg));
 
 			mobilePageWrapper.consentViewPage.eleButton("Privacy Settings").click();
-			softAssert.assertTrue(mobilePageWrapper.privacyManagerPage.isPrivacyManagerViewPresent());
+			logMessage("Verify all toggle button displayed as false");
+
+			softAssert.assertTrue(mobilePageWrapper.privacyManagerPage.isPrivacyManagerViewPresent(),
+					"Privacy Manager not displayed");
 
 			// check PM data for all false
 
 		} catch (Exception e) {
-			System.out.println(e);
+			logMessage("Exception: " + e);
 			throw e;
 		} finally {
 			softAssert.assertAll();
@@ -170,18 +174,19 @@ public class CCPA_MetaAppTests extends BaseTest {
 	}
 
 	@Test(groups = { "CCPASDKTests" }, priority = 3)
+	@Description("Given user submit valid property details and tap on Save Then expected\n"
+			+ "	 consent message should display When user tap on Privacy Manager button And navigate to PM, all consent\n"
+			+ "	 toggle should show as selected When user tap on Reject all Then should see\n"
+			+ "	 same ConsentUUID data")
 	public void CheckConsentOnRejectAllFromPM() throws InterruptedException {
-
+		logMessage(" Test execution start : CheckConsentOnRejectAllFromPM");
 		SoftAssert softAssert = new SoftAssert();
 		setExpectedCAMsg();
-
 		String key = "region";
 		String value = "ca";
 		try {
-			System.out.println("***************** Test execution start *****************");
-			System.out.println("CheckConsentOnRejectAllFromPM - " + String.valueOf(Thread.currentThread().getId()));
-
 			MobilePageWrapper mobilePageWrapper = new MobilePageWrapper(driver);
+			logMessage("Enter property details...");
 			mobilePageWrapper.siteListPage.CCPAAddButton.click();
 			mobilePageWrapper.newSitePage.CCPAAccountID.sendKeys(accountId);
 			mobilePageWrapper.newSitePage.CCPASiteId.sendKeys(siteID);
@@ -192,23 +197,28 @@ public class CCPA_MetaAppTests extends BaseTest {
 					mobilePageWrapper.newSitePage.CCPAParameterValue, key, value);
 			mobilePageWrapper.newSitePage.CCPAParameterAddButton.click();
 			mobilePageWrapper.newSitePage.CCPASaveButton.click();
+			logMessage("Check for the message and tap on Privacy Settings");
 
 			ArrayList<String> consentMessage = mobilePageWrapper.consentViewPage.getConsentMessageDetails();
-			softAssert.assertTrue(consentMessage.containsAll(expectedCAMsg));
+			softAssert.assertTrue(consentMessage.containsAll(expectedCAMsg), "Expected consent message not displayed");
 
 			mobilePageWrapper.consentViewPage.eleButton("Privacy Settings").click();
 
-			softAssert.assertTrue(mobilePageWrapper.privacyManagerPage.isPrivacyManagerViewPresent());
-			// check for all purposes selected as true
+			softAssert.assertTrue(mobilePageWrapper.privacyManagerPage.isPrivacyManagerViewPresent(),
+					"Privacy Manager not displayed");
+			logMessage("Tap on Reject All and check updated consent informations");
 
 			mobilePageWrapper.privacyManagerPage.ccpa_RejectAllButton.click();
+			logMessage("Get consent information : ConsentUUID: "
+					+ mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID.getText());
+
 			softAssert.assertNotEquals(mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID.getText(),
 					"ConsentUUID not available");
 
 			softAssert.assertTrue(mobilePageWrapper.siteDebugInfoPage
 					.checkForNoPurposeConsentData(mobilePageWrapper.siteDebugInfoPage.CCPAConsentNotAvailable));
 		} catch (Exception e) {
-			System.out.println(e);
+			logMessage("Exception: " + e);
 			throw e;
 		} finally {
 			softAssert.assertAll();
@@ -216,19 +226,21 @@ public class CCPA_MetaAppTests extends BaseTest {
 	}
 
 	@Test(groups = { "CCPASDKTests" }, priority = 4)
+	@Description("Given user submit valid property details and tap on Save "
+			+ "Then expected message should display When user tap on Privacy Settings "
+			+ "Then all vendors/purposes should display as selected "
+			+ "When user tap on Reject All and navigate back Then no consent information should get stored"
+			+ "When user reset property cookies Then he/she should see message again"
+			+ "When user tap on Privacy Settng button Then all consent information data should displayed as true")
 	public void CheckPurposeConsentAfterResetCookies() throws InterruptedException {
-
+		logMessage("CheckPurposeConsentAfterResetCookies - " + String.valueOf(Thread.currentThread().getId()));
 		SoftAssert softAssert = new SoftAssert();
 		setExpectedCAMsg();
-
+		String key = "region";
+		String value = "ca";
 		try {
-			String key = "region";
-			String value = "ca";
-			System.out.println("***************** Test execution start *****************");
-			System.out.println(
-					"CheckPurposeConsentAfterResetCookies - " + String.valueOf(Thread.currentThread().getId()));
-
 			MobilePageWrapper mobilePageWrapper = new MobilePageWrapper(driver);
+			logMessage("Enter property details....");
 			mobilePageWrapper.siteListPage.CCPAAddButton.click();
 			mobilePageWrapper.newSitePage.CCPAAccountID.sendKeys(accountId);
 			mobilePageWrapper.newSitePage.CCPASiteId.sendKeys(siteID);
@@ -239,25 +251,25 @@ public class CCPA_MetaAppTests extends BaseTest {
 					mobilePageWrapper.newSitePage.CCPAParameterValue, key, value);
 			mobilePageWrapper.newSitePage.CCPAParameterAddButton.click();
 			mobilePageWrapper.newSitePage.CCPASaveButton.click();
+			logMessage("Check for message and tap on Privacy Settings button");
 
 			ArrayList<String> consentMessage = mobilePageWrapper.consentViewPage.getConsentMessageDetails();
 
-			softAssert.assertTrue(consentMessage.containsAll(expectedCAMsg));
+			softAssert.assertTrue(consentMessage.containsAll(expectedCAMsg), "Expected message not displayed");
 			mobilePageWrapper.consentViewPage.eleButton("Privacy Settings").click();
 
-			softAssert.assertTrue(mobilePageWrapper.privacyManagerPage.isPrivacyManagerViewPresent());
+			softAssert.assertTrue(mobilePageWrapper.privacyManagerPage.isPrivacyManagerViewPresent(),
+					"Privacy Manager not displayed");
 			// check for all purposes selected as false
-			// driver.hideKeyboard();
-			mobilePageWrapper.privacyManagerPage.ccpa_SaveAndExitButton.click();
+			mobilePageWrapper.privacyManagerPage.ccpa_RejectAllButton.click();
+			logMessage("Get consent information : ConsentUUID: "
+					+ mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID.getText());
+
 			softAssert.assertNotEquals(mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID.getText(),
 					"ConsentUUID not available");
-
-//				softAssert.assertTrue(mobilePageWrapper.siteDebugInfoPage
-//						.isConsentViewDataPresent(mobilePageWrapper.siteDebugInfoPage.CCPAConsentView));
-			ArrayList<String> consentData = mobilePageWrapper.siteDebugInfoPage
-					.storeConsent(mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID);
 			mobilePageWrapper.siteDebugInfoPage.BackButton.click();
 			softAssert.assertEquals(mobilePageWrapper.siteListPage.CCPASiteName.getText(), siteName);
+			logMessage("Delete cookies for the property and check for message");
 
 			mobilePageWrapper.siteListPage.swipeHorizontaly_ccpa(siteName);
 			mobilePageWrapper.siteListPage.CCPAResetButton.click();
@@ -266,14 +278,15 @@ public class CCPA_MetaAppTests extends BaseTest {
 
 			mobilePageWrapper.consentViewPage.YESButton.click();
 			softAssert.assertTrue(consentMessage.containsAll(expectedCAMsg));
+			logMessage("Tap on Privacy Setting button and check all consents are selected as true");
 
 			mobilePageWrapper.consentViewPage.eleButton("Privacy Settings").click();
-			softAssert.assertTrue(mobilePageWrapper.privacyManagerPage.isPrivacyManagerViewPresent());
-			System.out.println("passed");
+			softAssert.assertTrue(mobilePageWrapper.privacyManagerPage.isPrivacyManagerViewPresent(),
+					"Privacy Manager not displayed");
 			// check for all purposes selected as true
 
 		} catch (Exception e) {
-			System.out.println(e);
+			logMessage("Exception: " + e);
 			throw e;
 		} finally {
 			softAssert.assertAll();
@@ -281,20 +294,19 @@ public class CCPA_MetaAppTests extends BaseTest {
 	}
 
 	@Test(groups = { "CCPASDKTests" }, priority = 5)
+	@Description("Given user submit valid property details and tap on Save Then expected\n"
+			+ "	 consent message should display When user tap on Reject All from Then consent data\n"
+			+ "	 should get stored When user navigate to PM directly by clicking on Show PM\n"
+			+ "	 link Then all vendors/purposes should display as false")
 	public void CheckConsentDataFromPrivacyManagerDirect() throws InterruptedException {
-
+		logMessage("CheckConsentDataFromPrivacyManagerDirect - " + String.valueOf(Thread.currentThread().getId()));
 		SoftAssert softAssert = new SoftAssert();
 		setExpectedCAMsg();
-
 		String key = "region";
 		String value = "ca";
-
 		try {
-			System.out.println("***************** Test execution start *****************");
-			System.out.println(
-					"CheckConsentDataFromPrivacyManagerDirect - " + String.valueOf(Thread.currentThread().getId()));
-
 			MobilePageWrapper mobilePageWrapper = new MobilePageWrapper(driver);
+			logMessage("Enter property details....");
 			mobilePageWrapper.siteListPage.CCPAAddButton.click();
 			mobilePageWrapper.newSitePage.CCPAAccountID.sendKeys(accountId);
 			mobilePageWrapper.newSitePage.CCPASiteId.sendKeys(siteID);
@@ -305,21 +317,27 @@ public class CCPA_MetaAppTests extends BaseTest {
 					mobilePageWrapper.newSitePage.CCPAParameterValue, key, value);
 			mobilePageWrapper.newSitePage.CCPAParameterAddButton.click();
 			mobilePageWrapper.newSitePage.CCPASaveButton.click();
+			logMessage("Check for message and tap on Reject All button");
 
 			ArrayList<String> consentMessage = mobilePageWrapper.consentViewPage.getConsentMessageDetails();
-			softAssert.assertTrue(consentMessage.containsAll(expectedCAMsg));
+			softAssert.assertTrue(consentMessage.containsAll(expectedCAMsg), "Expected message not displayed");
 
 			mobilePageWrapper.consentViewPage.eleButton("Reject All").click();
+			logMessage("Get consent information : ConsentUUID: "
+					+ mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID.getText());
 
 			softAssert.assertNotEquals(mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID.getText(),
 					"ConsentUUID not available");
 
 			ArrayList<String> consentData = mobilePageWrapper.siteDebugInfoPage
 					.storeConsent(mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID);
+			logMessage("Tap on Show Pm link to display PM directly and check all consents are selected as false");
 
 			mobilePageWrapper.siteDebugInfoPage.CCPAShowPMLink.click();
 
-			softAssert.assertTrue(mobilePageWrapper.privacyManagerPage.isPrivacyManagerViewPresent());
+			softAssert.assertTrue(mobilePageWrapper.privacyManagerPage.isPrivacyManagerViewPresent(),
+					"Privacy Manager not displayed");
+			logMessage("Tap on Reject All button and check no consent data available ");
 
 			// check for all purposes selected as false
 			mobilePageWrapper.privacyManagerPage.ccpa_RejectAllButton.click();
@@ -328,7 +346,7 @@ public class CCPA_MetaAppTests extends BaseTest {
 					.checkForNoPurposeConsentData(mobilePageWrapper.siteDebugInfoPage.CCPAConsentNotAvailable));
 
 		} catch (Exception e) {
-			System.out.println(e);
+			logMessage("Exception : " + e);
 			throw e;
 		} finally {
 			softAssert.assertAll();
@@ -336,19 +354,19 @@ public class CCPA_MetaAppTests extends BaseTest {
 	}
 
 	@Test(groups = { "CCPASDKTests" }, priority = 6)
+	@Description("Given user submit valid property details and tap on Save Then expected\n"
+			+ "	 consent message should display When user tap on Reject All from Then no consent data\n"
+			+ "	 should get stored When user navigate to PM directly by clicking on Show PM\n"
+			+ "	 link And tap on Cancel Then he.she should navigate back to info screen with no consent data")
 	public void CheckCancelFromDirectPrivacyManager() throws InterruptedException {
-
+		logMessage("CheckCancelFromDirectPrivacyManager - " + String.valueOf(Thread.currentThread().getId()));
 		SoftAssert softAssert = new SoftAssert();
 		setExpectedCAMsg();
-
 		String key = "region";
 		String value = "ca";
 		try {
-			System.out.println("***************** Test execution start *****************");
-			System.out
-					.println("CheckCancelFromDirectPrivacyManager - " + String.valueOf(Thread.currentThread().getId()));
-
 			MobilePageWrapper mobilePageWrapper = new MobilePageWrapper(driver);
+			logMessage("Enter property details....");
 			mobilePageWrapper.siteListPage.CCPAAddButton.click();
 			mobilePageWrapper.newSitePage.CCPAAccountID.sendKeys(accountId);
 			mobilePageWrapper.newSitePage.CCPASiteId.sendKeys(siteID);
@@ -359,22 +377,30 @@ public class CCPA_MetaAppTests extends BaseTest {
 					mobilePageWrapper.newSitePage.CCPAParameterValue, key, value);
 			mobilePageWrapper.newSitePage.CCPAParameterAddButton.click();
 			mobilePageWrapper.newSitePage.CCPASaveButton.click();
+			logMessage("Check for message and tap on Reject All button");
 
 			ArrayList<String> consentMessage = mobilePageWrapper.consentViewPage.getConsentMessageDetails();
-			softAssert.assertTrue(consentMessage.containsAll(expectedCAMsg));
+			softAssert.assertTrue(consentMessage.containsAll(expectedCAMsg), "Expected message not displayed");
 
 			mobilePageWrapper.consentViewPage.eleButton("Reject All").click();
+			logMessage("Get consent information : ConsentUUID: "
+					+ mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID.getText());
 
 			softAssert.assertNotEquals(mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID.getText(),
 					"ConsentUUID not available");
 			ArrayList<String> consentData = mobilePageWrapper.siteDebugInfoPage
 					.storeConsent(mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID);
+			logMessage("Tap on Show link to display PM direct and tap on Cancel button");
 
 			mobilePageWrapper.siteDebugInfoPage.CCPAShowPMLink.click();
 
-			softAssert.assertTrue(mobilePageWrapper.privacyManagerPage.isPrivacyManagerViewPresent());
+			softAssert.assertTrue(mobilePageWrapper.privacyManagerPage.isPrivacyManagerViewPresent(),
+					"Privacy Manager not displayed");
 			// driver.hideKeyboard();
 			mobilePageWrapper.privacyManagerPage.ccpa_CancelButton.click();
+			logMessage("Check for no consent information");
+			logMessage("Get consent information : ConsentUUID: "
+					+ mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID.getText());
 
 			softAssert.assertEquals(mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID.getText(), consentData.get(0));
 			softAssert.assertTrue(mobilePageWrapper.siteDebugInfoPage
@@ -383,7 +409,7 @@ public class CCPA_MetaAppTests extends BaseTest {
 			// check for all purposes selected as false
 
 		} catch (Exception e) {
-			System.out.println(e);
+			logMessage("Exception:" + e);
 			throw e;
 		} finally {
 			softAssert.assertAll();
@@ -391,18 +417,19 @@ public class CCPA_MetaAppTests extends BaseTest {
 	}
 
 	@Test(groups = { "CCPAMetaAppTests" }, priority = 7)
+	@Description("Given user submit valid property details and tap on Save Then expected\n"
+			+ "	 consent message should display When user tap on Privacy Settings btton Then user should navigate to PM screen "
+			+ "  When user tap on Save and Exit Then navigate back to inof screen "
+			+ " When he/she agian tap on property Then he/she should not see message again")
 	public void CheckNoConsentMessageDisplayAfterShowSiteInfo() throws InterruptedException {
+		logMessage("CheckNoConsentMessageDisplayAfterShowSiteInfo - " + String.valueOf(Thread.currentThread().getId()));
 		SoftAssert softAssert = new SoftAssert();
-
 		setShowOnceExpectedMsg();
+		String key = "displayMode";
+		String value = "appLaunch";
 		try {
-			String key = "displayMode";
-			String value = "appLaunch";
-			System.out.println("***************** Test execution start *****************");
-			System.out.println("CheckNoConsentMessageDisplayAfterShowSiteInfo - "
-					+ String.valueOf(Thread.currentThread().getId()));
-
 			MobilePageWrapper mobilePageWrapper = new MobilePageWrapper(driver);
+			logMessage("Enter property details....");
 			mobilePageWrapper.siteListPage.CCPAAddButton.click();
 			mobilePageWrapper.newSitePage.CCPAAccountID.sendKeys(accountId);
 			mobilePageWrapper.newSitePage.CCPASiteId.sendKeys(siteID);
@@ -413,31 +440,34 @@ public class CCPA_MetaAppTests extends BaseTest {
 					mobilePageWrapper.newSitePage.CCPAParameterValue, key, value);
 			mobilePageWrapper.newSitePage.CCPAParameterAddButton.click();
 			mobilePageWrapper.newSitePage.CCPASaveButton.click();
+			logMessage("Check for message and tap on Privacy Settings button");
 
 			ArrayList<String> actualConsentMessage = mobilePageWrapper.consentViewPage.getConsentMessageDetails();
-			softAssert.assertTrue(actualConsentMessage.containsAll(expectedShowOnceMsg));
+			softAssert.assertTrue(actualConsentMessage.containsAll(expectedShowOnceMsg),
+					"Expected message not displayed");
 
 			mobilePageWrapper.consentViewPage.eleButton("Privacy Settings").click();
-			softAssert.assertTrue(mobilePageWrapper.privacyManagerPage.isPrivacyManagerViewPresent());
-			// driver.hideKeyboard();
-			logMessage("check details");
+			softAssert.assertTrue(mobilePageWrapper.privacyManagerPage.isPrivacyManagerViewPresent(),
+					"Privacy Manager not displayed");
+			logMessage("Tap on Save and Exit button and check for consent information");
 			mobilePageWrapper.privacyManagerPage.ccpa_SaveAndExitButton.click();
 			softAssert.assertNotEquals(mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID.getText(),
 					"ConsentUUID not available");
 
-//			softAssert.assertTrue(mobilePageWrapper.siteDebugInfoPage.isConsentViewDataPresent(mobilePageWrapper.siteDebugInfoPage.CCPAConsentView));
+			logMessage("Get consent information : ConsentUUID: "
+					+ mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID.getText());
 
 			ArrayList<String> consentData = mobilePageWrapper.siteDebugInfoPage
 					.storeConsent(mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID);
 			mobilePageWrapper.siteDebugInfoPage.BackButton.click();
 			softAssert.assertEquals(mobilePageWrapper.siteListPage.CCPASiteName.getText(), siteName);
 			mobilePageWrapper.siteListPage.tapOnSite_ccpa(siteName, mobilePageWrapper.siteListPage.CCPASiteList);
-			logMessage("check details");
+			logMessage("Tap on the site again from property list and check for the consent information");
 
 			Assert.assertEquals(mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID.getText(), consentData.get(0));
 
 		} catch (Exception e) {
-			System.out.println(e);
+			logMessage("Exception : " + e);
 			throw e;
 		} finally {
 			softAssert.assertAll();
@@ -445,17 +475,19 @@ public class CCPA_MetaAppTests extends BaseTest {
 	}
 
 	@Test(groups = { "CCPAMetaAppTests" }, priority = 8)
+	@Description("Given user submit valid property details and tap on Save Then expected\n"
+			+ "	 consent message should display When user tap on Privacy Settings button Then user should navigate to PM screen "
+			+ "  When user tap on Save and Exit Then navigate back to inof screen "
+			+ "  When he/she delete property cookies Then he/she should see message again")
 	public void CheckConsentMessageDisplayAfterDeleteCookies() throws InterruptedException {
+		logMessage("CheckConsentMessageDisplayAfterDeleteCookies - " + String.valueOf(Thread.currentThread().getId()));
 		SoftAssert softAssert = new SoftAssert();
 		setShowOnceExpectedMsg();
+		String key = "displayMode";
+		String value = "appLaunch";
 		try {
-			String key = "displayMode";
-			String value = "appLaunch";
-			System.out.println("***************** Test execution start *****************");
-			System.out.println(
-					"CheckConsentMessageDisplayAfterDeleteCookies - " + String.valueOf(Thread.currentThread().getId()));
-
 			MobilePageWrapper mobilePageWrapper = new MobilePageWrapper(driver);
+			logMessage("Enter property details....");
 			mobilePageWrapper.siteListPage.CCPAAddButton.click();
 			mobilePageWrapper.newSitePage.CCPAAccountID.sendKeys(accountId);
 			mobilePageWrapper.newSitePage.CCPASiteId.sendKeys(siteID);
@@ -467,13 +499,18 @@ public class CCPA_MetaAppTests extends BaseTest {
 			mobilePageWrapper.newSitePage.CCPAParameterAddButton.click();
 			mobilePageWrapper.newSitePage.CCPASaveButton.click();
 
+			logMessage("Check for message and tap on Privacy Settings button");
 			ArrayList<String> consentMessage = mobilePageWrapper.consentViewPage.getConsentMessageDetails();
-			softAssert.assertTrue(consentMessage.containsAll(expectedShowOnceMsg));
+			softAssert.assertTrue(consentMessage.containsAll(expectedShowOnceMsg), "Expected message not displayed");
 
 			mobilePageWrapper.consentViewPage.eleButton("Privacy Settings").click();
-			softAssert.assertTrue(mobilePageWrapper.privacyManagerPage.isPrivacyManagerViewPresent());
+			softAssert.assertTrue(mobilePageWrapper.privacyManagerPage.isPrivacyManagerViewPresent(),
+					"Privacy Manager not displayed");
 			// driver.hideKeyboard();
 			mobilePageWrapper.privacyManagerPage.ccpa_SaveAndExitButton.click();
+			logMessage("Get consent information : ConsentUUID: "
+					+ mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID.getText());
+
 			softAssert.assertNotEquals(mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID.getText(),
 					"ConsentUUID not available");
 
@@ -488,6 +525,7 @@ public class CCPA_MetaAppTests extends BaseTest {
 
 			mobilePageWrapper.siteDebugInfoPage.BackButton.click();
 			mobilePageWrapper.siteListPage.swipeHorizontaly_ccpa(siteName);
+			logMessage("reset cookies and check for the message");
 			mobilePageWrapper.siteListPage.CCPAResetButton.click();
 			softAssert.assertTrue(mobilePageWrapper.consentViewPage.verifyDeleteCookiesMessage());
 			mobilePageWrapper.consentViewPage.YESButton.click();
@@ -496,7 +534,7 @@ public class CCPA_MetaAppTests extends BaseTest {
 			softAssert.assertTrue(consentMessage1.containsAll(expectedShowOnceMsg));
 
 		} catch (Exception e) {
-			System.out.println(e);
+			logMessage("Exception :" + e);
 			throw e;
 		} finally {
 			softAssert.assertAll();
@@ -504,18 +542,19 @@ public class CCPA_MetaAppTests extends BaseTest {
 	}
 
 	@Test(groups = { "CCPAMetaAppTests" }, priority = 9)
+	@Description("Given user submit valid property details and tap on Save Then expected\n"
+			+ "	 consent message should display When user tap on Reject All button "
+			+ "Then user should navigate to info screen with no consent information")
 	public void CheckConsentForTargetingParameterAfterRejectAll() throws InterruptedException {
 		SoftAssert softAssert = new SoftAssert();
-
+		logMessage(
+				"CheckConsentForTargetingParameterAfterRejectAll - " + String.valueOf(Thread.currentThread().getId()));
 		setExpectedCAMsg();
+		String key = "region";
+		String value = "ca";
 		try {
-			String key = "region";
-			String value = "ca";
-			System.out.println("***************** Test execution start *****************");
-			System.out.println("CheckConsentForTargetingParameterAfterRejectAll - "
-					+ String.valueOf(Thread.currentThread().getId()));
-
 			MobilePageWrapper mobilePageWrapper = new MobilePageWrapper(driver);
+			logMessage("Enter property details....");
 			mobilePageWrapper.siteListPage.CCPAAddButton.click();
 			mobilePageWrapper.newSitePage.CCPAAccountID.sendKeys(accountId);
 			mobilePageWrapper.newSitePage.CCPASiteId.sendKeys(siteID);
@@ -526,21 +565,19 @@ public class CCPA_MetaAppTests extends BaseTest {
 					mobilePageWrapper.newSitePage.CCPAParameterValue, key, value);
 			mobilePageWrapper.newSitePage.CCPAParameterAddButton.click();
 			mobilePageWrapper.newSitePage.CCPASaveButton.click();
+			logMessage("Check for message and tap on Reject All button");
 
 			ArrayList<String> consentMessage = mobilePageWrapper.consentViewPage.getConsentMessageDetails();
-
-			softAssert.assertTrue(consentMessage.containsAll(expectedCAMsg));
+			softAssert.assertTrue(consentMessage.containsAll(expectedCAMsg), "Expected message not displayed");
 
 			mobilePageWrapper.consentViewPage.eleButton("Reject All").click();
-//				softAssert.assertNotEquals(mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID.getText(),
-//						"ConsentUUID not available");
-//				softAssert.assertTrue(mobilePageWrapper.siteDebugInfoPage
-//						.checkForNoPurposeConsentData(mobilePageWrapper.siteDebugInfoPage.CCPAConsentNotAvailable));
+			logMessage("Get consent information : ConsentUUID: "
+					+ mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID.getText());
 
 			mobilePageWrapper.siteDebugInfoPage.BackButton.click();
 			softAssert.assertEquals(mobilePageWrapper.siteListPage.CCPASiteName.getText(), siteName);
 		} catch (Exception e) {
-			System.out.println(e);
+			logMessage("Exception : " + e);
 			throw e;
 		} finally {
 			softAssert.assertAll();
@@ -548,17 +585,17 @@ public class CCPA_MetaAppTests extends BaseTest {
 	}
 
 	@Test(groups = { "CCPAMetaAppTests" }, priority = 10)
+	@Description("Given user submit valid property details and tap on Save Then expected\n"
+			+ "	 consent message should display When user navigate to PM and tap on Save and Exit button "
+			+ "Then user should navigate to info screen with consent information")
 	public void CheckConsentForTargetingParameterAfterAcceptAll() throws InterruptedException {
 		SoftAssert softAssert = new SoftAssert();
-
+		logMessage(
+				"CheckConsentMessageDisplayForTargetingParameter - " + String.valueOf(Thread.currentThread().getId()));
 		setExpectedCAMsg();
+		String key = "region";
+		String value = "ca";
 		try {
-			String key = "region";
-			String value = "ca";
-			System.out.println("***************** Test execution start *****************");
-			System.out.println("CheckConsentMessageDisplayForTargetingParameter - "
-					+ String.valueOf(Thread.currentThread().getId()));
-
 			MobilePageWrapper mobilePageWrapper = new MobilePageWrapper(driver);
 			mobilePageWrapper.siteListPage.CCPAAddButton.click();
 			mobilePageWrapper.newSitePage.CCPAAccountID.sendKeys(accountId);
@@ -570,24 +607,25 @@ public class CCPA_MetaAppTests extends BaseTest {
 					mobilePageWrapper.newSitePage.CCPAParameterValue, key, value);
 			mobilePageWrapper.newSitePage.CCPAParameterAddButton.click();
 			mobilePageWrapper.newSitePage.CCPASaveButton.click();
+			logMessage("Check for message and tap on Privacy Settings button");
 
 			ArrayList<String> consentMessage = mobilePageWrapper.consentViewPage.getConsentMessageDetails();
-			softAssert.assertTrue(consentMessage.containsAll(expectedCAMsg));
+			softAssert.assertTrue(consentMessage.containsAll(expectedCAMsg), "Expected message not displayed");
 
 			mobilePageWrapper.consentViewPage.eleButton("Privacy Settings").click();
 			softAssert.assertTrue(mobilePageWrapper.privacyManagerPage.isPrivacyManagerViewPresent());
-			// driver.hideKeyboard();
+			logMessage("Tap on Save and exit button");
 
 			mobilePageWrapper.privacyManagerPage.ccpa_SaveAndExitButton.click();
+			logMessage("Get consent information : ConsentUUID: "
+					+ mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID.getText());
+
 			softAssert.assertNotEquals(mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID.getText(),
 					"ConsentUUID not available");
-
-			// softAssert.assertTrue(mobilePageWrapper.siteDebugInfoPage.isConsentViewDataPresent(mobilePageWrapper.siteDebugInfoPage.CCPAConsentView));
-
 			mobilePageWrapper.siteDebugInfoPage.BackButton.click();
 			softAssert.assertEquals(mobilePageWrapper.siteListPage.CCPASiteName.getText(), siteName);
 		} catch (Exception e) {
-			System.out.println(e);
+			logMessage("Exception :" + e);
 			throw e;
 		} finally {
 			softAssert.assertAll();
@@ -595,17 +633,17 @@ public class CCPA_MetaAppTests extends BaseTest {
 	}
 
 	@Test(groups = { "CCPAMetaAppTests" }, priority = 11)
+	@Description("Given user submit valid property details and tap on Save Then expected\n"
+			+ "	 consent message should display When delete property then property should get removed from list")
 	public void DeleteSite() throws InterruptedException {
 		SoftAssert softAssert = new SoftAssert();
-
+		logMessage("DeleteSite - " + String.valueOf(Thread.currentThread().getId()));
 		setExpectedCAMsg();
+		String key = "region";
+		String value = "ca";
 		try {
-			String key = "region";
-			String value = "ca";
-			System.out.println("***************** Test execution start *****************");
-			System.out.println("DeleteSite - " + String.valueOf(Thread.currentThread().getId()));
-
 			MobilePageWrapper mobilePageWrapper = new MobilePageWrapper(driver);
+			logMessage("Enter property details....");
 			mobilePageWrapper.siteListPage.CCPAAddButton.click();
 			mobilePageWrapper.newSitePage.CCPAAccountID.sendKeys(accountId);
 			mobilePageWrapper.newSitePage.CCPASiteId.sendKeys(siteID);
@@ -616,31 +654,34 @@ public class CCPA_MetaAppTests extends BaseTest {
 					mobilePageWrapper.newSitePage.CCPAParameterValue, key, value);
 			mobilePageWrapper.newSitePage.CCPAParameterAddButton.click();
 			mobilePageWrapper.newSitePage.CCPASaveButton.click();
+			logMessage("Check for message and tap on Reject All button");
 
 			ArrayList<String> consentMessage = mobilePageWrapper.consentViewPage.getConsentMessageDetails();
-			softAssert.assertTrue(consentMessage.containsAll(expectedCAMsg));
+			softAssert.assertTrue(consentMessage.containsAll(expectedCAMsg), "Expected message not displayed");
 
 			mobilePageWrapper.consentViewPage.eleButton("Reject All").click();
+			logMessage("Get consent information : ConsentUUID: "
+					+ mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID.getText());
 			softAssert.assertNotEquals(mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID.getText(),
 					"ConsentUUID not available");
 
 			mobilePageWrapper.siteDebugInfoPage.BackButton.click();
 
 			softAssert.assertEquals(mobilePageWrapper.siteListPage.CCPASiteName.getText(), siteName);
-
+			logMessage("Delete property");
 			mobilePageWrapper.siteListPage.swipeHorizontaly_ccpa(siteName);
 			mobilePageWrapper.siteListPage.CCPADeleteButton.click();
-			// softAssert.assertTrue(mobilePageWrapper.siteListPage.verifyDeleteSiteMessage());
+			softAssert.assertTrue(mobilePageWrapper.siteListPage.verifyDeleteSiteMessage());
 
 			mobilePageWrapper.siteListPage.NOButton.click();
 
 			mobilePageWrapper.siteListPage.swipeHorizontaly_ccpa(siteName);
 			mobilePageWrapper.siteListPage.CCPADeleteButton.click();
-			// softAssert.assertTrue(mobilePageWrapper.siteListPage.verifyDeleteSiteMessage(udid));
+			softAssert.assertTrue(mobilePageWrapper.siteListPage.verifyDeleteSiteMessage());
 
 			mobilePageWrapper.siteListPage.YESButton.click();
 		} catch (Exception e) {
-			System.out.println(e);
+			logMessage("Exception : " + e);
 			throw e;
 		} finally {
 			softAssert.assertAll();
@@ -648,8 +689,13 @@ public class CCPA_MetaAppTests extends BaseTest {
 	}
 
 	@Test(groups = { "CCPAMetaAppTests" }, priority = 12)
+	@Description("Given user submit valid property details and tap on Save Then expected\n"
+			+ "	 consent message should display When user tap on Reject All "
+			+ "Then user should navigate to info screen with no consent information "
+			+ "When user edit the property details with new data and save "
+			+ "Then he/she should see rescpective message configured for the new property")
 	public void EditSiteWithNoConsentGivenBefore() throws InterruptedException {
-
+		logMessage("EditSiteWithNoConsentGivenBefore - " + String.valueOf(Thread.currentThread().getId()));
 		setExpectedCAMsg();
 		setAnotherExpectedCAMsg();
 		String key = "region";
@@ -657,10 +703,8 @@ public class CCPA_MetaAppTests extends BaseTest {
 		SoftAssert softAssert = new SoftAssert();
 		ArrayList<String> consentData;
 		try {
-			System.out.println("***************** Test execution start *****************");
-			System.out.println("EditSiteWithNoConsentGivenBefore - " + String.valueOf(Thread.currentThread().getId()));
-
 			MobilePageWrapper mobilePageWrapper = new MobilePageWrapper(driver);
+			logMessage("Enter property details....");
 			mobilePageWrapper.siteListPage.CCPAAddButton.click();
 			mobilePageWrapper.newSitePage.CCPAAccountID.sendKeys(accountId);
 			mobilePageWrapper.newSitePage.CCPASiteId.sendKeys(siteID);
@@ -671,11 +715,14 @@ public class CCPA_MetaAppTests extends BaseTest {
 					mobilePageWrapper.newSitePage.CCPAParameterValue, key, value);
 			mobilePageWrapper.newSitePage.CCPAParameterAddButton.click();
 			mobilePageWrapper.newSitePage.CCPASaveButton.click();
+			logMessage("Check for message and tap on Reject all button");
 
 			ArrayList<String> consentMessage = mobilePageWrapper.consentViewPage.getConsentMessageDetails();
-			softAssert.assertTrue(consentMessage.containsAll(expectedCAMsg));
+			softAssert.assertTrue(consentMessage.containsAll(expectedCAMsg), "Expected message not displayed");
 
 			mobilePageWrapper.consentViewPage.eleButton("Reject All").click();
+			logMessage("Get consent information : ConsentUUID: "
+					+ mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID.getText());
 			softAssert.assertNotEquals(mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID.getText(),
 					"ConsentUUID not available");
 
@@ -684,24 +731,19 @@ public class CCPA_MetaAppTests extends BaseTest {
 			mobilePageWrapper.siteDebugInfoPage.BackButton.click();
 
 			softAssert.assertEquals(mobilePageWrapper.siteListPage.CCPASiteName.getText(), siteName);
+			logMessage("Edit with new property details having no given consent before");
 
 			mobilePageWrapper.siteListPage.swipeHorizontaly_ccpa(siteName);
 			mobilePageWrapper.siteListPage.CCPAEditButton.click();
 			mobilePageWrapper.newSitePage.CCPASiteId.sendKeys("6168");
 			mobilePageWrapper.newSitePage.CCPASiteName.sendKeys("ccpa.cybage.testing.com");
 			mobilePageWrapper.newSitePage.selectCampaign(mobilePageWrapper.newSitePage.CCPAToggleButton, "ON");
-
 			mobilePageWrapper.newSitePage.CCPASaveButton.click();
-
-			ArrayList<String> consentMessage1 = mobilePageWrapper.consentViewPage1.getConsentMessageDetails();
-
-			// softAssert.assertTrue(consentMessage1.containsAll(expectedAnotherCAMsg));
+			logMessage("Check message and tap on Privacy Setting button");
 
 			mobilePageWrapper.consentViewPage.eleButton("Privacy Settings").click();
-
-			softAssert.assertTrue(mobilePageWrapper.privacyManagerPage.isPrivacyManagerViewPresent());
-			// driver.hideKeyboard();
-
+			softAssert.assertTrue(mobilePageWrapper.privacyManagerPage.isPrivacyManagerViewPresent(),
+					"Privacy Manager not displayed");
 			mobilePageWrapper.privacyManagerPage.ccpa_SaveAndExitButton.click();
 			softAssert.assertNotEquals(mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID.getText(),
 					"ConsentUUID not available");
@@ -710,7 +752,7 @@ public class CCPA_MetaAppTests extends BaseTest {
 					.isConsentViewDataPresent(mobilePageWrapper.siteDebugInfoPage.CCPAConsentView));
 
 		} catch (Exception e) {
-			System.out.println(e);
+			logMessage("Exception: " + e);
 			throw e;
 		} finally {
 			softAssert.assertAll();
@@ -718,18 +760,20 @@ public class CCPA_MetaAppTests extends BaseTest {
 	}
 
 	@Test(groups = { "CCPAMetaAppTests" }, priority = 13)
+	@Description("Given user submit valid property details and tap on Save Then expected\n"
+			+ "	 consent message should display When user navigate to PM and tap on Save & Exit "
+			+ " Then user should navigate to info screen with consent information When user reset the property cookies"
+			+ "Then he/she should see expected message")
 	public void ResetCookies() throws InterruptedException {
+		logMessage("ResetCookies - " + String.valueOf(Thread.currentThread().getId()));
 		SoftAssert softAssert = new SoftAssert();
 		setShowOnceExpectedMsg();
-
+		String key = "displayMode";
+		String value = "appLaunch";
 		ArrayList<String> consentData;
 		try {
-			String key = "displayMode";
-			String value = "appLaunch";
-			System.out.println("***************** Test execution start *****************");
-			System.out.println("ResetCookies - " + String.valueOf(Thread.currentThread().getId()));
-
 			MobilePageWrapper mobilePageWrapper = new MobilePageWrapper(driver);
+			logMessage("Enter property details...");
 			mobilePageWrapper.siteListPage.CCPAAddButton.click();
 			mobilePageWrapper.newSitePage.CCPAAccountID.sendKeys(accountId);
 			mobilePageWrapper.newSitePage.CCPASiteId.sendKeys(siteID);
@@ -740,25 +784,28 @@ public class CCPA_MetaAppTests extends BaseTest {
 					mobilePageWrapper.newSitePage.CCPAParameterValue, key, value);
 			mobilePageWrapper.newSitePage.CCPAParameterAddButton.click();
 			mobilePageWrapper.newSitePage.CCPASaveButton.click();
+			logMessage("Check for message and tap on Privacy Settings button");
 
 			ArrayList<String> consentMessage = mobilePageWrapper.consentViewPage.getConsentMessageDetails();
-			softAssert.assertTrue(consentMessage.containsAll(expectedShowOnceMsg));
+			softAssert.assertTrue(consentMessage.containsAll(expectedShowOnceMsg),
+					"Expected consent message not displayed");
 
 			mobilePageWrapper.consentViewPage.eleButton("Privacy Settings").click();
-
-			softAssert.assertTrue(mobilePageWrapper.privacyManagerPage.isPrivacyManagerViewPresent());
-			// driver.hideKeyboard();
+			softAssert.assertTrue(mobilePageWrapper.privacyManagerPage.isPrivacyManagerViewPresent(),
+					"Privacy Manager not displayed");
+			logMessage("Tap on Save and Exit button");
 
 			mobilePageWrapper.privacyManagerPage.ccpa_SaveAndExitButton.click();
+			logMessage("Get consent information : ConsentUUID: "
+					+ mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID.getText());
 			softAssert.assertNotEquals(mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID.getText(),
 					"ConsentUUID not available");
 
-			// softAssert.assertTrue(mobilePageWrapper.siteDebugInfoPage.isConsentViewDataPresent(mobilePageWrapper.siteDebugInfoPage.CCPAConsentView));
+			logMessage("Reset the cookie for the property");
 			consentData = mobilePageWrapper.siteDebugInfoPage
 					.storeConsent(mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID);
 
 			mobilePageWrapper.siteDebugInfoPage.BackButton.click();
-
 			softAssert.assertEquals(mobilePageWrapper.siteListPage.CCPASiteName.getText(), siteName);
 
 			mobilePageWrapper.siteListPage.swipeHorizontaly_ccpa(siteName);
@@ -771,7 +818,7 @@ public class CCPA_MetaAppTests extends BaseTest {
 			softAssert.assertTrue(consentMessage1.containsAll(expectedShowOnceMsg));
 
 		} catch (Exception e) {
-			System.out.println(e);
+			logMessage("Exception: " + e);
 			throw e;
 		} finally {
 			softAssert.assertAll();
@@ -779,67 +826,68 @@ public class CCPA_MetaAppTests extends BaseTest {
 	}
 
 	@Test(groups = { "CCPAMetaAppTests" }, priority = 14)
+	@Description("Given user submit valid property details with authentication and tap on Save Then expected\n"
+			+ "	 consent message should display When user navigate to PM and tap on Save & exit "
+			+ "Then user should navigate to info screen with consent information "
+			+ "When user reset property cookies Then he/she shouldnot see message again")
 	public void CheckNoMessageWithShowOnceCriteriaWhenConsentAlreadySaved() throws Exception {
+		logMessage(" Test execution start ; CheckNoMessageWithShowOnceCriteriaWhenConsentAlreadySaved");
 		SoftAssert softAssert = new SoftAssert();
 		setShowOnceExpectedMsg();
-
+		String key = "displayMode";
+		String value = "appLaunch";
 		try {
-			String key = "displayMode";
-			String value = "appLaunch";
-			System.out.println("***************** Test execution start *****************");
-			System.out.println("CheckNoMessageWithShowOnceCriteriaWhenConsentAlreadySaved - "
-					+ String.valueOf(Thread.currentThread().getId()));
-
 			MobilePageWrapper mobilePageWrapper = new MobilePageWrapper(driver);
+			logMessage("Enter property details with unique authentication...");
 			mobilePageWrapper.siteListPage.CCPAAddButton.click();
 			mobilePageWrapper.newSitePage.CCPAAccountID.sendKeys(accountId);
 			mobilePageWrapper.newSitePage.CCPASiteId.sendKeys(siteID);
 			mobilePageWrapper.newSitePage.CCPASiteName.sendKeys(siteName);
 			mobilePageWrapper.newSitePage.CCPAPMId.sendKeys(pmID);
 			mobilePageWrapper.newSitePage.selectCampaign(mobilePageWrapper.newSitePage.CCPAToggleButton, staggingValue);
-
 			Date date = new Date();
 			mobilePageWrapper.newSitePage.CCPAAuthID.sendKeys(sdf.format(date));
-
 			mobilePageWrapper.newSitePage.addTargetingParameter(mobilePageWrapper.newSitePage.CCPAParameterKey,
 					mobilePageWrapper.newSitePage.CCPAParameterValue, key, value);
 			mobilePageWrapper.newSitePage.CCPAParameterAddButton.click();
 
 			mobilePageWrapper.newSitePage.CCPASaveButton.click();
-			ArrayList<String> consentData;
+			logMessage("Check for message and tap on Privacy Setting button");
 
-			// mobilePageWrapper.consentViewPage.loadTime();
 			ArrayList<String> consentMessage = mobilePageWrapper.consentViewPage.getConsentMessageDetails();
-			softAssert.assertTrue(consentMessage.containsAll(expectedShowOnceMsg));
+			softAssert.assertTrue(consentMessage.containsAll(expectedShowOnceMsg), "Expected message not displayed");
 
 			mobilePageWrapper.consentViewPage.eleButton("Privacy Settings").click();
 
-			softAssert.assertTrue(mobilePageWrapper.privacyManagerPage.isPrivacyManagerViewPresent());
-			// driver.hideKeyboard();
+			softAssert.assertTrue(mobilePageWrapper.privacyManagerPage.isPrivacyManagerViewPresent(),
+					"Privacy Manager not displayed");
+			logMessage("Tap on Save and Exit button");
 
 			mobilePageWrapper.privacyManagerPage.ccpa_SaveAndExitButton.click();
-			Thread.sleep(3000);
+			logMessage("Get consent information : ConsentUUID: "
+					+ mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID.getText());
 			softAssert.assertNotEquals(mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID.getText(),
 					"ConsentUUID not available");
-
-//			softAssert.assertTrue(mobilePageWrapper.siteDebugInfoPage.isConsentViewDataPresent(mobilePageWrapper.siteDebugInfoPage.CCPAConsentView));
-			consentData = mobilePageWrapper.siteDebugInfoPage
+			ArrayList<String> consentData = mobilePageWrapper.siteDebugInfoPage
 					.storeConsent(mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID);
 
 			mobilePageWrapper.siteDebugInfoPage.BackButton.click();
-
 			softAssert.assertEquals(mobilePageWrapper.siteListPage.CCPASiteName.getText(), siteName);
+			logMessage("Reset the cookies for the property");
 
 			mobilePageWrapper.siteListPage.swipeHorizontaly_ccpa(siteName);
 			mobilePageWrapper.siteListPage.CCPAResetButton.click();
+			softAssert.assertTrue(mobilePageWrapper.consentViewPage.verifyDeleteCookiesMessage());
 
-			// softAssert.assertTrue(mobilePageWrapper.consentViewPage.verifyDeleteCookiesMessage());
 			mobilePageWrapper.consentViewPage.YESButton.click();
-			Thread.sleep(3000);
-			softAssert.assertEquals(mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID.getText(), consentData.get(0));
+			logMessage("Get consent information : ConsentUUID: "
+					+ mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID.getText());
+			softAssert.assertFalse(mobilePageWrapper.privacyManagerPage.isPrivacyManagerViewPresent());
+			softAssert.assertEquals(mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID.getText(), consentData.get(0),
+					"ConsentUUID not matching");
 
 		} catch (Exception e) {
-			System.out.println(e);
+			logMessage("Exception: " + e);
 			throw e;
 		} finally {
 			softAssert.assertAll();
@@ -847,21 +895,22 @@ public class CCPA_MetaAppTests extends BaseTest {
 	}
 
 	@Test(groups = { "CCPAMetaAppTests" }, priority = 15)
+	@Description("Given user submit valid property details with authentication and tap on Save Then expected\n"
+			+ "	 consent message should display When user navigate to PM and tap on Reject All button "
+			+ "Then user should navigate to info screen with no consent information "
+			+ "When user add same property with new unquie authentication details "
+			+ "Then he/she should message and see consent data as selected on PM")
 	public void CheckSavedConsentAlwaysWithSameAuthID() throws Exception {
+		logMessage(" Test execution start :CheckSavedConsentAlwaysWithSameAuthID");
 		setExpectedCAMsg();
 		String key = "region";
 		String value = "ca";
 		Date date = new Date();
 		ArrayList<String> consentData;
-
 		SoftAssert softAssert = new SoftAssert();
-
 		try {
-			System.out.println("***************** Test execution start *****************");
-			System.out.println(
-					"CheckSavedConsentAlwaysWithSameAuthID - " + String.valueOf(Thread.currentThread().getId()));
-
 			MobilePageWrapper mobilePageWrapper = new MobilePageWrapper(driver);
+			logMessage("Enter property details with unique authentication....");
 			mobilePageWrapper.siteListPage.CCPAAddButton.click();
 			mobilePageWrapper.newSitePage.CCPAAccountID.sendKeys(accountId);
 			mobilePageWrapper.newSitePage.CCPASiteId.sendKeys(siteID);
@@ -871,25 +920,22 @@ public class CCPA_MetaAppTests extends BaseTest {
 
 			authID = sdf.format(date);
 			mobilePageWrapper.newSitePage.CCPAAuthID.sendKeys(authID);
-			System.out.println("AuthID : " + authID);
+			logMessage("Unique AuthID : " + authID);
 			mobilePageWrapper.newSitePage.addTargetingParameter(mobilePageWrapper.newSitePage.CCPAParameterKey,
 					mobilePageWrapper.newSitePage.CCPAParameterValue, key, value);
 			mobilePageWrapper.newSitePage.CCPAParameterAddButton.click();
-
 			mobilePageWrapper.newSitePage.CCPASaveButton.click();
+			logMessage("Check for message and tap on Reject All from PM");
 
 			ArrayList<String> consentMessage = mobilePageWrapper.consentViewPage.getConsentMessageDetails();
-			softAssert.assertTrue(consentMessage.containsAll(expectedCAMsg));
-
-			// mobilePageWrapper.consentViewPage.PrivacySettingsButton);
+			softAssert.assertTrue(consentMessage.containsAll(expectedCAMsg), "Expected message not displayed");
 			mobilePageWrapper.consentViewPage.eleButton("Privacy Settings").click();
 
-			softAssert.assertTrue(mobilePageWrapper.privacyManagerPage.isPrivacyManagerViewPresent());
-//				driver.hideKeyboard();
-
+			softAssert.assertTrue(mobilePageWrapper.privacyManagerPage.isPrivacyManagerViewPresent(),
+					"Privacy Manager not displayed");
 			mobilePageWrapper.privacyManagerPage.ccpa_RejectAllButton.click();
-			// mobilePageWrapper.privacyManagerPage.eleButton(udid, "Reject
-			// All"));
+			logMessage("Get consent information : ConsentUUID: "
+					+ mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID.getText());
 
 			softAssert.assertNotEquals(mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID.getText(),
 					"ConsentUUID not available");
@@ -899,6 +945,7 @@ public class CCPA_MetaAppTests extends BaseTest {
 			mobilePageWrapper.siteDebugInfoPage.BackButton.click();
 
 			softAssert.assertEquals(mobilePageWrapper.siteListPage.CCPASiteName.getText(), siteName);
+			logMessage("Create new property with same details but some other unique authentication");
 
 			mobilePageWrapper.siteListPage.CCPAAddButton.click();
 			mobilePageWrapper.newSitePage.CCPAAccountID.sendKeys(accountId);
@@ -906,242 +953,88 @@ public class CCPA_MetaAppTests extends BaseTest {
 			mobilePageWrapper.newSitePage.CCPASiteName.sendKeys(siteName);
 			mobilePageWrapper.newSitePage.CCPAPMId.sendKeys(pmID);
 			mobilePageWrapper.newSitePage.selectCampaign(mobilePageWrapper.newSitePage.CCPAToggleButton, staggingValue);
-
-//			mobilePageWrapper.newSitePage.CCPAAuthID.sendKeys(authID);
-//			System.out.println("AuthID : " + authID);
+			Date date2 = new Date();
+			authID = sdf.format(date2);
+			mobilePageWrapper.newSitePage.CCPAAuthID.sendKeys(authID);
+			logMessage("Unique AuthID : " + authID);
 			mobilePageWrapper.newSitePage.addTargetingParameter(mobilePageWrapper.newSitePage.CCPAParameterKey,
 					mobilePageWrapper.newSitePage.CCPAParameterValue, key, value);
 			mobilePageWrapper.newSitePage.CCPAParameterAddButton.click();
 			mobilePageWrapper.newSitePage.CCPASaveButton.click();
+			logMessage("Check for message and check all toggles displyed as false from PM");
 
 			ArrayList<String> consentMessage1 = mobilePageWrapper.consentViewPage1.getConsentMessageDetails();
 			softAssert.assertTrue(consentMessage1.containsAll(expectedCAMsg));
 
 			mobilePageWrapper.consentViewPage.eleButton("Privacy Settings").click();
-			softAssert.assertTrue(mobilePageWrapper.privacyManagerPage.isPrivacyManagerViewPresent());
+			softAssert.assertTrue(mobilePageWrapper.privacyManagerPage.isPrivacyManagerViewPresent(),
+					"Privacy Manager not displayed");
 
 			// Check all consent are saves as true
 		} catch (Exception e) {
-			System.out.println(e);
+			logMessage("Exception: " + e);
 			throw e;
 		} finally {
 			softAssert.assertAll();
 		}
 	}
 
-//	@Test(groups = { "CCPAMetaAppTests" }, priority = 16)
-	public void CheckConsentWithSameAuthIDWithNewInstallation() throws Exception {
-		setExpectedCAMsg();
-		String key = "region";
-		String value = "ca";
-
-		SoftAssert softAssert = new SoftAssert();
-
-		try {
-			System.out.println("***************** Test execution start *****************");
-			System.out.println("CheckConsentWithSameAuthIDWithNewInstallation - "
-					+ String.valueOf(Thread.currentThread().getId()));
-
-			MobilePageWrapper mobilePageWrapper = new MobilePageWrapper(driver);
-			mobilePageWrapper.siteListPage.CCPAAddButton.click();
-			mobilePageWrapper.newSitePage.CCPAAccountID.sendKeys(accountId);
-			mobilePageWrapper.newSitePage.CCPASiteId.sendKeys(siteID);
-			mobilePageWrapper.newSitePage.CCPASiteName.sendKeys(siteName);
-			mobilePageWrapper.newSitePage.CCPAPMId.sendKeys(pmID);
-			mobilePageWrapper.newSitePage.selectCampaign(mobilePageWrapper.newSitePage.CCPAToggleButton, staggingValue);
-
-			Date date1 = new Date();
-			authID = sdf.format(date1);
-			mobilePageWrapper.newSitePage.CCPAAuthID.sendKeys(authID);
-			System.out.println("AuthID : " + authID);
-			mobilePageWrapper.newSitePage.addTargetingParameter(mobilePageWrapper.newSitePage.CCPAParameterKey,
-					mobilePageWrapper.newSitePage.CCPAParameterValue, key, value);
-			mobilePageWrapper.newSitePage.CCPAParameterAddButton.click();
-			mobilePageWrapper.newSitePage.CCPASaveButton.click();
-
-			ArrayList<String> consentMessage = mobilePageWrapper.consentViewPage.getConsentMessageDetails();
-
-			softAssert.assertTrue(consentMessage.containsAll(expectedCAMsg));
-
-			mobilePageWrapper.consentViewPage.eleButton("Privacy Settings").click();
-
-			softAssert.assertTrue(mobilePageWrapper.privacyManagerPage.isPrivacyManagerViewPresent());
-			// driver.hideKeyboard();
-
-			mobilePageWrapper.privacyManagerPage.ccpa_RejectAllButton.click();
-			softAssert.assertNotEquals(mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID.getText(),
-					"ConsentUUID not available");
-
-			mobilePageWrapper.siteDebugInfoPage.BackButton.click();
-
-			softAssert.assertEquals(mobilePageWrapper.siteListPage.CCPASiteName.getText(), siteName);
-
-			System.out.println("Uninstall app");
-			// mobilePageWrapper.siteListPage.removeCCPAApp();
-
-			System.out.println("Install app");
-			// mobilePageWrapper.siteListPage.installApp();
-
-			MobilePageWrapper mobilePageWrapper1 = new MobilePageWrapper(driver);
-			mobilePageWrapper1.siteListPage.CCPAAddButton.click();
-			mobilePageWrapper1.newSitePage.CCPAAccountID.sendKeys(accountId);
-			mobilePageWrapper1.newSitePage.CCPASiteId.sendKeys(siteID);
-			mobilePageWrapper1.newSitePage.CCPASiteName.sendKeys(siteName);
-			mobilePageWrapper1.newSitePage.CCPAPMId.sendKeys(pmID);
-			mobilePageWrapper1.newSitePage.selectCampaign(mobilePageWrapper.newSitePage.CCPAToggleButton,
-					staggingValue);
-			mobilePageWrapper1.newSitePage.CCPAAuthID.sendKeys(authID);
-
-			mobilePageWrapper.newSitePage.addTargetingParameter(mobilePageWrapper1.newSitePage.CCPAParameterKey,
-					mobilePageWrapper1.newSitePage.CCPAParameterValue, key, value);
-			mobilePageWrapper.newSitePage.CCPAParameterAddButton.click();
-			mobilePageWrapper1.newSitePage.CCPASaveButton.click();
-
-			ArrayList<String> consentMessage1 = mobilePageWrapper1.consentViewPage.getConsentMessageDetails();
-			softAssert.assertTrue(consentMessage1.containsAll(expectedCAMsg));
-
-			mobilePageWrapper.consentViewPage.eleButton("Privacy Settings").click();
-
-			softAssert.assertTrue(mobilePageWrapper1.privacyManagerPage.isPrivacyManagerViewPresent());
-
-			// Check all consent are save as false
-		} catch (Exception e) {
-			System.out.println(e);
-			throw e;
-		} finally {
-			softAssert.assertAll();
-		}
-	}
-
-//	@Test(groups = { "CCPAMetaAppTests" }, priority = 17)
-	public void CheckSavedConsentAlwaysWithSameAuthIDCrossPlatform() throws Exception {
-
-		setExpectedCAMsg();
-		String key = "region";
-		String value = "ca";
-		SoftAssert softAssert = new SoftAssert();
-
-		try {
-			System.out.println("***************** Test execution start *****************");
-			System.out.println("CheckSavedConsentAlwaysWithSameAuthIDCrossPlatform - "
-					+ String.valueOf(Thread.currentThread().getId()));
-
-			MobilePageWrapper mobilePageWrapper = new MobilePageWrapper(driver);
-
-			mobilePageWrapper.siteListPage.CCPAAddButton.click();
-			mobilePageWrapper.newSitePage.CCPAAccountID.sendKeys(accountId);
-			mobilePageWrapper.newSitePage.CCPASiteId.sendKeys(siteID);
-			mobilePageWrapper.newSitePage.CCPASiteName.sendKeys(siteName);
-			mobilePageWrapper.newSitePage.CCPAPMId.sendKeys(pmID);
-			mobilePageWrapper.newSitePage.selectCampaign(mobilePageWrapper.newSitePage.CCPAToggleButton, staggingValue);
-
-			Date date1 = new Date();
-			authID = sdf.format(date1);
-			mobilePageWrapper.newSitePage.CCPAAuthID.sendKeys(authID);
-			mobilePageWrapper.newSitePage.addTargetingParameter(mobilePageWrapper.newSitePage.CCPAParameterKey,
-					mobilePageWrapper.newSitePage.CCPAParameterValue, key, value);
-			mobilePageWrapper.newSitePage.CCPAParameterAddButton.click();
-			mobilePageWrapper.newSitePage.CCPASaveButton.click();
-
-			ArrayList<String> consentMessage = mobilePageWrapper.consentViewPage.getConsentMessageDetails();
-			softAssert.assertTrue(consentMessage.containsAll(expectedCAMsg));
-
-			mobilePageWrapper.consentViewPage.eleButton("Privacy Settings").click();
-
-			softAssert.assertTrue(mobilePageWrapper.privacyManagerPage.isPrivacyManagerViewPresent());
-			// driver.hideKeyboard();
-
-			mobilePageWrapper.privacyManagerPage.ccpa_RejectAllButton.click();
-			softAssert.assertNotEquals(mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID.getText(),
-					"ConsentUUID not available");
-
-			mobilePageWrapper.siteDebugInfoPage.BackButton.click();
-
-			softAssert.assertEquals(mobilePageWrapper.siteListPage.CCPASiteName.getText(), siteName);
-
-//				String baseDir = DirectoryOperations.getProjectRootPath();
-//				System.setProperty("webdriver.chrome.driver", baseDir + "/setupfiles/Fusion/chromedriver_MAC");
-//
-//				WebDriver driver1 = new ChromeDriver(); // init chrome driver
-//
-//				driver1.get("https://in-app-messaging.pm.sourcepoint.mgr.consensu.org/v2.0.html?\r\n" + "\r\n"
-//						+ "_sp_accountId=" + accountId + "&_sp_writeFirstPartyCookies=true&_sp_msg_domain=mms.sp-\r\n"
-//						+ "\r\n" + "prod.net&_sp_debug_level=OFF&_sp_pmOrigin=production&_sp_siteHref=https%3A%2F%2F"
-//						+ siteName + "\r\n" + "\r\n" + "%2F&_sp_msg_targetingParams=\r\n" + "\r\n" + "%7B\"" + key
-//						+ "\"%3A\"" + value + "\"%7D&_sp_authId=" + authID
-//						+ "&_sp_cmp_inApp=true&_sp_msg_stageCampaign=" + staggingValue + "&_sp_cmp_origin=%2F\r\n"
-//						+ "\r\n" + "%2Fsourcepoint.mgr.consensu.org");
-//
-//				Thread.sleep(5000);
-//				driver1.findElement(By.id("Show Purposes")).click();
-//				Thread.sleep(3000);
-//			WebDriverWait wait = new WebDriverWait(webDriver, 30);
-//			wait.until(ExpectedConditions.presenceOfElementLocated(By.className("priv_main_parent")));
-// Check all consent are save as true
-
-//			driver1.quit();
-		} catch (Exception e) {
-			System.out.println(e);
-			throw e;
-		} finally {
-			softAssert.assertAll();
-		}
-	}
-
-	@Test(groups = { "CCPAMetaAppTests" }, priority = 18)
+	@Test(groups = { "CCPAMetaAppTests" }, priority = 16)
+	@Description("Given user submit valid property details with authentication and tap on Save Then expected\n"
+			+ "	 consent message should display When user navigate to PM and tap on Reject All button "
+			+ "Then user should navigate to info screen with no consent information "
+			+ "When user delete the property and recreate same Then he/she should see message And should see consent as false from PM")
 	public void CheckConsentWithSameAuthIDAfterDeletingAndRecreate() throws Exception {
+		logMessage("CheckConsentWithSameAuthIDAfterDeletingAndRecreate - "
+				+ String.valueOf(Thread.currentThread().getId()));
 		setExpectedCAMsg();
 		String key = "region";
 		String value = "ca";
-
 		SoftAssert softAssert = new SoftAssert();
-
 		try {
-			System.out.println("***************** Test execution start *****************");
-			System.out.println("CheckConsentWithSameAuthIDAfterDeletingAndRecreate - "
-					+ String.valueOf(Thread.currentThread().getId()));
-
 			MobilePageWrapper mobilePageWrapper = new MobilePageWrapper(driver);
+			logMessage("Enter property details with unique authentication...");
 			mobilePageWrapper.siteListPage.CCPAAddButton.click();
 			mobilePageWrapper.newSitePage.CCPAAccountID.sendKeys(accountId);
 			mobilePageWrapper.newSitePage.CCPASiteId.sendKeys(siteID);
 			mobilePageWrapper.newSitePage.CCPASiteName.sendKeys(siteName);
 			mobilePageWrapper.newSitePage.CCPAPMId.sendKeys(pmID);
 			mobilePageWrapper.newSitePage.selectCampaign(mobilePageWrapper.newSitePage.CCPAToggleButton, staggingValue);
-
 			Date date1 = new Date();
 			authID = sdf.format(date1);
 			mobilePageWrapper.newSitePage.CCPAAuthID.sendKeys(authID);
-			System.out.println("AuthID : " + authID);
+			logMessage("AuthID : " + authID);
 			mobilePageWrapper.newSitePage.addTargetingParameter(mobilePageWrapper.newSitePage.CCPAParameterKey,
 					mobilePageWrapper.newSitePage.CCPAParameterValue, key, value);
 			mobilePageWrapper.newSitePage.CCPAParameterAddButton.click();
 			mobilePageWrapper.newSitePage.CCPASaveButton.click();
+			logMessage("Check message and tap on Privacy Settings button");
 
 			ArrayList<String> consentMessage = mobilePageWrapper.consentViewPage.getConsentMessageDetails();
-			softAssert.assertTrue(consentMessage.containsAll(expectedCAMsg));
+			softAssert.assertTrue(consentMessage.containsAll(expectedCAMsg), "Expected message not displayed");
 
 			mobilePageWrapper.consentViewPage.eleButton("Privacy Settings").click();
-
-			softAssert.assertTrue(mobilePageWrapper.privacyManagerPage.isPrivacyManagerViewPresent());
-//				driver.hideKeyboard();
+			softAssert.assertTrue(mobilePageWrapper.privacyManagerPage.isPrivacyManagerViewPresent(),
+					"Privacy Manager not displayed");
 
 			mobilePageWrapper.privacyManagerPage.ccpa_RejectAllButton.click();
+			logMessage("Get consent information : ConsentUUID: "
+					+ mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID.getText());
 			softAssert.assertNotEquals(mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID.getText(),
 					"ConsentUUID not available");
 
 			mobilePageWrapper.siteDebugInfoPage.BackButton.click();
-
+			logMessage("Delete the property");
 			softAssert.assertEquals(mobilePageWrapper.siteListPage.CCPASiteName.getText(), siteName);
 
 			mobilePageWrapper.siteListPage.swipeHorizontaly_ccpa(siteName);
 			mobilePageWrapper.siteListPage.CCPADeleteButton.click();
-			// softAssert.assertTrue(mobilePageWrapper.siteListPage.verifyDeleteSiteMessage(udid));
+			softAssert.assertTrue(mobilePageWrapper.siteListPage.verifyDeleteSiteMessage());
 
 			mobilePageWrapper.siteListPage.YESButton.click();
-			// softAssert.assertFalse(mobilePageWrapper.siteListPage.isSitePressent_ccpa(siteName));
+			softAssert.assertFalse(mobilePageWrapper.siteListPage.isSitePressent_ccpa(siteName));
+			logMessage("Create property again with same Authentication details");
 
-			// MobilePageWrapper mobilePageWrapper1 = new MobilePageWrapper(driver);
 			mobilePageWrapper.siteListPage.CCPAAddButton.click();
 			mobilePageWrapper.newSitePage.CCPAAccountID.sendKeys(accountId);
 			mobilePageWrapper.newSitePage.CCPASiteId.sendKeys(siteID);
@@ -1149,88 +1042,88 @@ public class CCPA_MetaAppTests extends BaseTest {
 			mobilePageWrapper.newSitePage.CCPAPMId.sendKeys(pmID);
 			mobilePageWrapper.newSitePage.selectCampaign(mobilePageWrapper.newSitePage.CCPAToggleButton, staggingValue);
 			mobilePageWrapper.newSitePage.CCPAAuthID.sendKeys(authID);
-
 			mobilePageWrapper.newSitePage.addTargetingParameter(mobilePageWrapper.newSitePage.CCPAParameterKey,
 					mobilePageWrapper.newSitePage.CCPAParameterValue, key, value);
 			mobilePageWrapper.newSitePage.CCPAParameterAddButton.click();
 			mobilePageWrapper.newSitePage.CCPASaveButton.click();
+			logMessage("Check for all toggels as false from PM");
 
 			ArrayList<String> consentMessage1 = mobilePageWrapper.consentViewPage.getConsentMessageDetails();
 			softAssert.assertTrue(consentMessage1.containsAll(expectedCAMsg));
-
 			mobilePageWrapper.consentViewPage.eleButton("Privacy Settings").click();
-
-			softAssert.assertTrue(mobilePageWrapper.privacyManagerPage.isPrivacyManagerViewPresent());
+			softAssert.assertTrue(mobilePageWrapper.privacyManagerPage.isPrivacyManagerViewPresent(),
+					"Privacy Manager not displayed");
 
 			// Check all consent are save as false
 		} catch (Exception e) {
-			System.out.println(e);
+			logMessage("Exception: " + e);
 			throw e;
 		} finally {
 			softAssert.assertAll();
 		}
 	}
 
-	@Test(groups = { "CCPAMetaAppTests" }, priority = 19)
+	@Test(groups = { "CCPAMetaAppTests" }, priority = 17)
+	@Description("Given user submit valid property details and tap on Save Then expected\n"
+			+ "	 consent message should display When user navigate to PM and tap on Save & Exit"
+			+ "Then user should navigate to info screen with consent information "
+			+ "When user edit property with authentication Then he/she should not see message again")
 	public void CheckNoMessageAfterLoggedInWithAuthID() throws Exception {
+		logMessage("CheckNoMessageAfterLoggedInWithAuthID - " + String.valueOf(Thread.currentThread().getId()));
 		setShowOnceExpectedMsg();
 		String key = "displayMode";
 		String value = "appLaunch";
 		Date date = new Date();
 		String authID = sdf.format(date);
-
 		SoftAssert softAssert = new SoftAssert();
-
 		try {
-			System.out.println(" Test execution start ");
-			System.out.println(
-					"CheckNoMessageAfterLoggedInWithAuthID - " + String.valueOf(Thread.currentThread().getId()));
-
 			MobilePageWrapper mobilePageWrapper = new MobilePageWrapper(driver);
+			logMessage("Enter property details...");
 			mobilePageWrapper.siteListPage.CCPAAddButton.click();
 			mobilePageWrapper.newSitePage.CCPAAccountID.sendKeys(accountId);
 			mobilePageWrapper.newSitePage.CCPASiteId.sendKeys(siteID);
 			mobilePageWrapper.newSitePage.CCPASiteName.sendKeys(siteName);
 			mobilePageWrapper.newSitePage.CCPAPMId.sendKeys(pmID);
 			mobilePageWrapper.newSitePage.selectCampaign(mobilePageWrapper.newSitePage.CCPAToggleButton, staggingValue);
-
 			mobilePageWrapper.newSitePage.addTargetingParameter(mobilePageWrapper.newSitePage.CCPAParameterKey,
 					mobilePageWrapper.newSitePage.CCPAParameterValue, key, value);
 			mobilePageWrapper.newSitePage.CCPAParameterAddButton.click();
 			mobilePageWrapper.newSitePage.CCPASaveButton.click();
+			logMessage("Check for message and tap on Privacy Settings button");
 
 			ArrayList<String> consentMessage = mobilePageWrapper.consentViewPage.getConsentMessageDetails();
 
-			softAssert.assertTrue(consentMessage.containsAll(expectedShowOnceMsg));
+			softAssert.assertTrue(consentMessage.containsAll(expectedShowOnceMsg), "Expected message not displayed");
 			mobilePageWrapper.consentViewPage.eleButton("Privacy Settings").click();
 
-			softAssert.assertTrue(mobilePageWrapper.privacyManagerPage.isPrivacyManagerViewPresent());
-			// driver.hideKeyboard();
-
+			softAssert.assertTrue(mobilePageWrapper.privacyManagerPage.isPrivacyManagerViewPresent(),
+					"Privacy Manager not displayed");
+			logMessage("Tap on Save and Exit and check for consent information");
 			mobilePageWrapper.privacyManagerPage.ccpa_SaveAndExitButton.click();
-			Thread.sleep(5000);
+			logMessage("Get consent information : ConsentUUID: "
+					+ mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID.getText());
 			softAssert.assertNotEquals(mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID.getText(),
 					"ConsentUUID not available");
 
-//			softAssert.assertTrue(mobilePageWrapper.siteDebugInfoPage.isConsentViewDataPresent(mobilePageWrapper.siteDebugInfoPage.CCPAConsentView));
 			ArrayList<String> consentData = mobilePageWrapper.siteDebugInfoPage
 					.storeConsent(mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID);
-
 			mobilePageWrapper.siteDebugInfoPage.BackButton.click();
+			logMessage("Edit property details with unique authid");
 
 			softAssert.assertEquals(mobilePageWrapper.siteListPage.CCPASiteName.getText(), siteName);
 			mobilePageWrapper.siteListPage.swipeHorizontaly_ccpa(siteName);
-
 			mobilePageWrapper.siteListPage.CCPAEditButton.click();
 			mobilePageWrapper.newSitePage.CCPAAuthID.sendKeys(authID);
 			mobilePageWrapper.newSitePage.CCPASaveButton.click();
+			logMessage("Get consent information : ConsentUUID: "
+					+ mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID.getText());
 
 			softAssert.assertNotEquals(mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID.getText(),
 					"ConsentUUID not available");
 			softAssert.assertEquals(mobilePageWrapper.siteDebugInfoPage.CCPAConsentUUID.getText(), consentData.get(0));
 
 		} catch (Exception e) {
-			System.out.println(e);
+			logMessage("Exception: " + e);
 			throw e;
 		} finally {
 			softAssert.assertAll();

--- a/AutomationFramework/src/main/resources/allure.properties
+++ b/AutomationFramework/src/main/resources/allure.properties
@@ -1,0 +1,2 @@
+allure.results.directory=target/allure-results
+

--- a/AutomationFramework/src/main/resources/testng.xml
+++ b/AutomationFramework/src/main/resources/testng.xml
@@ -2,7 +2,9 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
 
 <suite name="Test Execution" parallel="none">
-
+ <listeners>
+		<listener class-name="org.framework.retryAnalyzer.RetryListener"></listener>
+	</listeners>
     <test name="E2E Test Suite On Android - emulator-5554">
         <parameter name="platformType" value="mobile"/>
         <parameter name="platformName" value="android"/>


### PR DESCRIPTION
Implement retry logic to re-run failed tests before declaring as actual failure. For MetaApp testing currently we are considering max 3 as retry count for failed test to re-execute.

