### PR TITLE
SP-4420 implement onAction callback

### DIFF
--- a/app/src/main/java/com/sourcepoint/test_project/MainActivity.java
+++ b/app/src/main/java/com/sourcepoint/test_project/MainActivity.java
@@ -37,7 +37,6 @@ public class MainActivity extends AppCompatActivity {
 
     private CCPAConsentLib buildCCPAConsentLib() {
         return CCPAConsentLib.newBuilder(config.accountId, config.propertyName, config.propertyId, config.pmId,this)
-                .setTargetingParam("SDK_TYPE","CCPA")
                 .setOnConsentUIReady(consentLib -> {
                     showMessageWebView(consentLib.webView);
                     Log.i(TAG, "onConsentUIReady");
@@ -73,7 +72,6 @@ public class MainActivity extends AppCompatActivity {
     protected void onResume() {
         super.onResume();
         buildCCPAConsentLib().run();
-        //buildGDPRConsentLib().run();
     }
 
     @Override
@@ -84,7 +82,6 @@ public class MainActivity extends AppCompatActivity {
         config = getConfig(R.raw.ccpa_mobile_demo);
         findViewById(R.id.review_consents).setOnClickListener(_v -> {
             buildCCPAConsentLib().showPm();
-            //buildGDPRConsentLib().showPm();
         });
     }
 

--- a/app/src/main/java/com/sourcepoint/test_project/MainActivity.java
+++ b/app/src/main/java/com/sourcepoint/test_project/MainActivity.java
@@ -41,6 +41,9 @@ public class MainActivity extends AppCompatActivity {
                     showMessageWebView(consentLib.webView);
                     Log.i(TAG, "onConsentUIReady");
                 })
+                .setOnAction(consentLib -> {
+                    Log.d(TAG, "user took the action: "+consentLib.choiceType);
+                })
                 .setOnConsentUIFinished(consentLib -> {
                     removeWebView(consentLib.webView);
                     Log.i(TAG, "onConsentUIFinished");

--- a/ccpa_cmplibrary/src/main/java/com/sourcepoint/ccpa_cmplibrary/CCPAConsentLib.java
+++ b/ccpa_cmplibrary/src/main/java/com/sourcepoint/ccpa_cmplibrary/CCPAConsentLib.java
@@ -38,7 +38,6 @@ public class CCPAConsentLib {
 
     private final String CCPA_ORIGIN = "https://ccpa-service.sp-prod.net";
 
-
     private String metaData;
 
     public enum DebugLevel {DEBUG, OFF}
@@ -50,7 +49,6 @@ public class CCPAConsentLib {
 
     public String consentUUID;
     public Boolean ccpaApplies;
-
 
     /**
      * After the user has chosen an option in the WebView, this attribute will contain an integer
@@ -69,10 +67,9 @@ public class CCPAConsentLib {
     private final String property;
     private final int accountId, propertyId;
     private final ViewGroup viewGroup;
-    private Callback onAction, onConsentReady, onError;
-    private Callback onConsentUIReady, onConsentUIFinished;
+    private Callback onAction, onConsentReady, onError, onConsentUIReady, onConsentUIFinished;
 
-    private final boolean weOwnTheView, isShowPM;
+    private final boolean weOwnTheView;
 
     //default time out changes
     private boolean onMessageReadyCalled = false;
@@ -121,7 +118,6 @@ public class CCPAConsentLib {
         accountId = b.accountId;
         propertyId = b.propertyId;
         pmId = b.pmId;
-        isShowPM = b.isShowPM;
         onAction = b.onAction;
         onConsentReady = b.onConsentReady;
 
@@ -201,7 +197,6 @@ public class CCPAConsentLib {
             @Override
             public void onAction(int choiceType) {
                 try{
-                    Log.d(TAG, "onAction:  " +  choiceType  + " + choiceType");
                     switch (choiceType) {
                         case ActionTypes.SHOW_PM:
                             CCPAConsentLib.this.choiceType = MESSAGE_OPTIONS.SHOW_PRIVACY_MANAGER;

--- a/ccpa_cmplibrary/src/main/java/com/sourcepoint/ccpa_cmplibrary/CCPAConsentLib.java
+++ b/ccpa_cmplibrary/src/main/java/com/sourcepoint/ccpa_cmplibrary/CCPAConsentLib.java
@@ -191,7 +191,9 @@ public class CCPAConsentLib {
 
             @Override
             public void onSavePM(UserConsent u) {
+                CCPAConsentLib.this.choiceType = MESSAGE_OPTIONS.SAVE_AND_EXIT;
                 CCPAConsentLib.this.userConsent = u;
+                CCPAConsentLib.this.onAction.run(CCPAConsentLib.this);
                 try {
                     sendConsent(ActionTypes.PM_COMPLETE);
                 } catch (Exception e) {
@@ -208,18 +210,22 @@ public class CCPAConsentLib {
                             onShowPm();
                             break;
                         case ActionTypes.MSG_ACCEPT:
+                            CCPAConsentLib.this.choiceType = MESSAGE_OPTIONS.ACCEPT_ALL;
                             onMsgAccepted();
                             break;
                         case ActionTypes.DISMISS:
+                            CCPAConsentLib.this.choiceType = MESSAGE_OPTIONS.MSG_CANCEL;
                             onDismiss();
                             break;
                         case ActionTypes.MSG_REJECT:
+                            CCPAConsentLib.this.choiceType = MESSAGE_OPTIONS.REJECT_ALL;
                             onMsgRejected();
                             break;
                         default:
                             CCPAConsentLib.this.choiceType = MESSAGE_OPTIONS.UNKNOWN;
                             break;
                     }
+                    CCPAConsentLib.this.onAction.run(CCPAConsentLib.this);
                 }catch (UnsupportedEncodingException e) {
                     onErrorTask(e);
                 } catch (JSONException e) {

--- a/ccpa_cmplibrary/src/main/java/com/sourcepoint/ccpa_cmplibrary/CCPAConsentLib.java
+++ b/ccpa_cmplibrary/src/main/java/com/sourcepoint/ccpa_cmplibrary/CCPAConsentLib.java
@@ -43,6 +43,11 @@ public class CCPAConsentLib {
     public enum DebugLevel {DEBUG, OFF}
 
     public enum MESSAGE_OPTIONS {
+        REJECT_ALL,
+        ACCEPT_ALL,
+        SAVE_AND_EXIT,
+        MSG_CANCEL,
+        PM_DISMISS,
         SHOW_PRIVACY_MANAGER,
         UNKNOWN
     }

--- a/ccpa_cmplibrary/src/main/java/com/sourcepoint/ccpa_cmplibrary/ConsentLibBuilder.java
+++ b/ccpa_cmplibrary/src/main/java/com/sourcepoint/ccpa_cmplibrary/ConsentLibBuilder.java
@@ -75,9 +75,6 @@ public class ConsentLibBuilder {
                 .getSystemService(Context.CONNECTIVITY_SERVICE);
     }
 
-
-
-    // TODO: add what are the possible choices returned to the Callback
     /**
      *  <b>Optional</b> Sets the Callback to be called when the user selects an option on the WebView.
      *  The selected choice will be available in the instance variable CCPAConsentLib.choiceType
@@ -85,7 +82,7 @@ public class ConsentLibBuilder {
      * @return ConsentLibBuilder - the next build step
      * @see ConsentLibBuilder
      */
-    public ConsentLibBuilder setOnMessageChoiceSelect(CCPAConsentLib.Callback c) {
+    public ConsentLibBuilder setOnAction(CCPAConsentLib.Callback c) {
         onAction = c;
         return this;
     }

--- a/ccpa_cmplibrary/src/main/java/com/sourcepoint/ccpa_cmplibrary/ConsentWebView.java
+++ b/ccpa_cmplibrary/src/main/java/com/sourcepoint/ccpa_cmplibrary/ConsentWebView.java
@@ -38,7 +38,6 @@ abstract public class ConsentWebView extends WebView {
 
     @SuppressWarnings("unused")
     private class MessageInterface {
-
         @JavascriptInterface
         public void log(String tag, String msg){
             Log.i(tag, msg);
@@ -49,24 +48,21 @@ abstract public class ConsentWebView extends WebView {
             Log.i("JS", msg);
         }
 
-        // called when message is about to be shown
         @JavascriptInterface
         public void onMessageReady() {
             Log.d("onMessageReady", "called");
             ConsentWebView.this.onMessageReady();
         }
 
-        // called when a choice is selected on the message
         @JavascriptInterface
         public void onAction(int choiceType) {
-            Log.d("onAction", "called");
+            Log.d(TAG, "onAction called with "+choiceType);
             ConsentWebView.this.onAction(choiceType);
         }
 
-        // called when a choice is selected on the message
         @JavascriptInterface
         public void onSavePM(String payloadStr) throws JSONException {
-            Log.d("onSavePM", "called");
+            Log.d(TAG, "onSavePM called with: "+payloadStr);
             JSONObject payloadJson = new JSONObject(payloadStr);
             ConsentWebView.this.onSavePM(
                     new UserConsent(
@@ -76,17 +72,15 @@ abstract public class ConsentWebView extends WebView {
             );
         }
 
-        //called when an error is occurred while loading web-view
         @JavascriptInterface
         public void onError(String errorType) {                               ;
             ConsentWebView.this.onError(new ConsentLibException("Something went wrong in the javascript world."));
         }
-        // xhr logger
+
         @JavascriptInterface
         public void xhrLog(String response){
             Log.d("xhrLog" , response);
         }
-
     }
 
     public ConsentWebView(Context context) {
@@ -132,7 +126,6 @@ abstract public class ConsentWebView extends WebView {
         this.setBackgroundColor(Color.TRANSPARENT);
         this.requestFocus();
         setWebViewClient(new WebViewClient() {
-
             @Override
             public void onPageFinished(WebView view, String url) {
                 super.onPageFinished(view, url);
@@ -208,7 +201,6 @@ abstract public class ConsentWebView extends WebView {
     }
 
     private String getFileContent(InputStream is) throws IOException {
-
         BufferedReader br = new BufferedReader( new InputStreamReader(is, "UTF-8" ));
         StringBuilder sb = new StringBuilder();
         String line;
@@ -233,9 +225,7 @@ abstract public class ConsentWebView extends WebView {
 
     abstract public void onSavePM(UserConsent userConsent);
 
-
     public void loadConsentMsgFromUrl(String url) {
-
         // On API level >= 21, the JavascriptInterface is not injected on the page until the *second* page load
         // so we need to issue blank load with loadData
         loadData("", "text/html", null);

--- a/ccpa_cmplibrary/src/test/java/com/sourcepoint/ccpa_cmplibrary/CCPAConsentLibBuilderTest.java
+++ b/ccpa_cmplibrary/src/test/java/com/sourcepoint/ccpa_cmplibrary/CCPAConsentLibBuilderTest.java
@@ -61,8 +61,8 @@ public class CCPAConsentLibBuilderTest {
     }
 
     @Test
-    public void setOnMessageChoiceSelect() {
-        consentLibBuilder.setOnMessageChoiceSelect(callback);
+    public void setOnAction() {
+        consentLibBuilder.setOnAction(callback);
         assertEquals(callback, consentLibBuilder.onAction);
     }
 

--- a/metaapp/src/main/java/com/sourcepointccpa/app/ui/ConsentViewActivity.java
+++ b/metaapp/src/main/java/com/sourcepointccpa/app/ui/ConsentViewActivity.java
@@ -98,9 +98,9 @@ public class ConsentViewActivity extends BaseActivity<ConsentViewViewModel> {
                 })
                 // optional, callback triggered when message choice is selected when called choice
                 // type will be available as Integer at cLib.choiceType
-                .setOnMessageChoiceSelect(ccpaConsentLib -> {
+                .setOnAction(ccpaConsentLib -> {
                     Log.i(TAG, "Choice type selected by user: " + ccpaConsentLib.choiceType.toString());
-                    Log.d(TAG, "setOnMessageChoiceSelect");
+                    Log.d(TAG, "setOnAction");
                 })
                 // optional, callback triggered when consent data is captured when called
                 .setOnConsentReady(ccpaConsentLib -> {

--- a/metaapp/src/main/java/com/sourcepointccpa/app/ui/NewPropertyActivity.java
+++ b/metaapp/src/main/java/com/sourcepointccpa/app/ui/NewPropertyActivity.java
@@ -104,9 +104,9 @@ public class NewPropertyActivity extends BaseActivity<NewPropertyViewModel> {
                 })
                 // optional, callback triggered when message choice is selected when called choice
                 // type will be available as Integer at cLib.choiceType
-                .setOnMessageChoiceSelect(ccpaConsentLib -> {
+                .setOnAction(ccpaConsentLib -> {
                     Log.i(TAG, "Choice type selected by user: " + ccpaConsentLib.choiceType.toString());
-                    Log.d(TAG, "setOnMessageChoiceSelect");
+                    Log.d(TAG, "setOnAction");
                 })
                 // optional, callback triggered when consent data is captured when called
                 .setOnConsentReady(ccpaConsentLib -> {


### PR DESCRIPTION
After this PR is merged and released our users will be able to track which action was taken by setting the `onAction` callback on the `ConsentLibBuilder`.

```java
.setOnAction(consentLib -> {
    Log.d(TAG, "user took the action: "+consentLib.choiceType);
})
```